### PR TITLE
Cleaning up Locking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ default: build
 
 test:
 	go get -d -t ./...
-	go test -timeout 20m -v ./lxd
+	go test -race -timeout 60m -v ./lxd
 
 testacc:
-	TF_LOG=debug TF_ACC=1 go test -v $(TESTARGS) -timeout 60m ./lxd
+	TF_LOG=debug TF_ACC=1 go test -v -race $(TESTARGS) -timeout 60m ./lxd
 
 build:
 	go build -v

--- a/lxd/provider_test.go
+++ b/lxd/provider_test.go
@@ -361,10 +361,8 @@ resource "lxd_noop" "noop1" {
 func resourceLxdNoOp() *schema.Resource {
 	return &schema.Resource{
 		Create: func(d *schema.ResourceData, meta interface{}) error {
-			remote := d.Get("remote").(string)
-			if remote == "" {
-				remote = meta.(*lxdProvider).Config.DefaultRemote
-			}
+			p := meta.(*lxdProvider)
+			remote := p.selectRemote(d)
 			_, err := meta.(*lxdProvider).GetServer(remote)
 			if err != nil {
 				return err
@@ -376,15 +374,12 @@ func resourceLxdNoOp() *schema.Resource {
 			d.Set("remote", d.Get("remote"))
 			return nil
 		},
-		Delete: func(d *schema.ResourceData, meta interface{}) error {
-			d.SetId("")
-			return nil
-		},
+
+		Delete: schema.RemoveFromState,
+
 		Read: func(d *schema.ResourceData, meta interface{}) error {
-			remote := d.Get("remote").(string)
-			if remote == "" {
-				remote = meta.(*lxdProvider).Config.DefaultRemote
-			}
+			p := meta.(*lxdProvider)
+			remote := p.selectRemote(d)
 			_, err := meta.(*lxdProvider).GetServer(remote)
 			if err != nil {
 				return err

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -652,13 +652,13 @@ func resourceLxdContainerImport(d *schema.ResourceData, meta interface{}) ([]*sc
 	log.Printf("[DEBUG] Starting import for %s", d.Id())
 	parts := strings.SplitN(d.Id(), "/", 2)
 
-	remote, name, err := p.Config.ParseRemote(parts[0])
+	remote, name, err := p.LXDConfig.ParseRemote(parts[0])
 	if err != nil {
 		return nil, err
 	}
 
 	d.SetId(name)
-	if p.Config.DefaultRemote != remote {
+	if p.LXDConfig.DefaultRemote != remote {
 		d.Set("remote", remote)
 	}
 

--- a/lxd/resource_lxd_container_file.go
+++ b/lxd/resource_lxd_container_file.go
@@ -112,7 +112,7 @@ func resourceLxdContainerFileCreate(d *schema.ResourceData, meta interface{}) er
 func resourceLxdContainerFileRead(d *schema.ResourceData, meta interface{}) error {
 	p := meta.(*lxdProvider)
 	v, targetFile := newFileIDFromResourceID(d.Id())
-	remote, containerName, err := p.Config.ParseRemote(v)
+	remote, containerName, err := p.LXDConfig.ParseRemote(v)
 
 	remote = p.selectRemote(d)
 	server, err := p.GetContainerServer(remote)
@@ -144,7 +144,7 @@ func resourceLxdContainerFileRead(d *schema.ResourceData, meta interface{}) erro
 func resourceLxdContainerFileDelete(d *schema.ResourceData, meta interface{}) error {
 	p := meta.(*lxdProvider)
 	v, targetFile := newFileIDFromResourceID(d.Id())
-	remote, containerName, err := p.Config.ParseRemote(v)
+	remote, containerName, err := p.LXDConfig.ParseRemote(v)
 	server, err := p.GetContainerServer(remote)
 	if err != nil {
 		return err
@@ -166,7 +166,7 @@ func resourceLxdContainerFileDelete(d *schema.ResourceData, meta interface{}) er
 func resourceLxdContainerFileExists(d *schema.ResourceData, meta interface{}) (exists bool, err error) {
 	p := meta.(*lxdProvider)
 	v, targetFile := newFileIDFromResourceID(d.Id())
-	remote, containerName, err := p.Config.ParseRemote(v)
+	remote, containerName, err := p.LXDConfig.ParseRemote(v)
 	if err != nil {
 		err = fmt.Errorf("unable to determine remote: %s", err)
 		return

--- a/lxd/resource_lxd_container_file_test.go
+++ b/lxd/resource_lxd_container_file_test.go
@@ -66,7 +66,7 @@ func testAccContainerFileExists(t *testing.T, n string, file *lxd.ContainerFileR
 
 		p := testAccProvider.Meta().(*lxdProvider)
 		v, targetFile := newFileIDFromResourceID(rs.Primary.ID)
-		remote, containerName, err := p.Config.ParseRemote(v)
+		remote, containerName, err := p.LXDConfig.ParseRemote(v)
 
 		client, err := p.GetContainerServer(remote)
 		if err != nil {

--- a/lxd/resource_lxd_network.go
+++ b/lxd/resource_lxd_network.go
@@ -69,7 +69,12 @@ func resourceLxdNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 	req := api.NetworksPost{Name: name}
 	req.Config = config
 	req.Description = desc
-	if err := server.CreateNetwork(req); err != nil {
+
+	mutex.Lock()
+	err = server.CreateNetwork(req)
+	mutex.Unlock()
+
+	if err != nil {
 		if err.Error() == "not implemented" {
 			err = errNetworksNotImplemented
 		}

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -226,14 +226,14 @@ func resourceLxdProfileExists(d *schema.ResourceData, meta interface{}) (exists 
 
 func resourceLxdProfileImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	p := meta.(*lxdProvider)
-	remote, name, err := p.Config.ParseRemote(d.Id())
+	remote, name, err := p.LXDConfig.ParseRemote(d.Id())
 
 	if err != nil {
 		return nil, err
 	}
 
 	d.SetId(name)
-	if p.Config.DefaultRemote != remote {
+	if p.LXDConfig.DefaultRemote != remote {
 		d.Set("remote", remote)
 	}
 

--- a/lxd/resource_lxd_storage_pool.go
+++ b/lxd/resource_lxd_storage_pool.go
@@ -173,7 +173,7 @@ func resourceLxdStoragePoolExists(d *schema.ResourceData, meta interface{}) (exi
 
 func resourceLxdStoragePoolImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	p := meta.(*lxdProvider)
-	remote, name, err := p.Config.ParseRemote(d.Id())
+	remote, name, err := p.LXDConfig.ParseRemote(d.Id())
 
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ func resourceLxdStoragePoolImport(d *schema.ResourceData, meta interface{}) ([]*
 	log.Printf("[DEBUG] Import storage pool from remote: %s name: %s", remote, name)
 
 	d.SetId(name)
-	if p.Config.DefaultRemote != remote {
+	if p.LXDConfig.DefaultRemote != remote {
 		d.Set("remote", remote)
 	}
 


### PR DESCRIPTION
This commit cleans up the locking done in the provider. It also
does another round of refactoring on the provider code by removing
unused code and renaming variables to be more clear.

For #137 