### PR TITLE
Support LXD virtual machine types

### DIFF
--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -64,6 +64,8 @@ resource "lxd_container" "container1" {
 
 * `image` - *Required* - Base image from which the container will be created.
 
+* `type` - *Optional* -  Instance type. Can be `"container"`, or `"virtual-machine`.
+
 * `profiles` - *Optional* - List of LXD config profiles to apply to the new
 	container.
 

--- a/lxd/shared.go
+++ b/lxd/shared.go
@@ -163,6 +163,28 @@ func resourceLxdValidateDeviceType(v interface{}, k string) (ws []string, errors
 	return
 }
 
+func resourceLxdValidateInstanceType(v interface{}, k string) (ws []string, errors []error) {
+	validTypes := []string{"container", "virtual-machine"}
+	value := v.(string)
+	valid := false
+
+	if v == nil {
+		return
+	}
+
+	for _, v := range validTypes {
+		if value == v {
+			valid = true
+		}
+	}
+
+	if !valid {
+		errors = append(errors, fmt.Errorf("Instance must have a type of: %v", validTypes))
+	}
+
+	return
+}
+
 // containerUploadFile will upload a file to a container.
 func containerUploadFile(server lxd.ContainerServer, container string, file File) error {
 	if file.Content != "" && file.Source != "" {


### PR DESCRIPTION
This MR adds a new attribute `type` to the `lxd_container` resources which is mapped to the LXD instance type, and can be used to create virtual machines instead of containers with recent LXD releases.

Unfortunately, I do not have enough time right now to create a new resource type as discussed in #202 but this MR provided a backward-compatible way to define virtual machines using the existing resource. The API should be compatible with much older LXD versions as the LXD client itself will fallback to the container only API when the server does not support the newer instances API (on a HTTP REST level).

With this a basic support for virtual machines would be ready.