### PR TITLE
Ensure storage pool tests use an empty directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.15"
+        channel:
+          - latest/stable
+          - latest/candidate
+
+    env:
+      TF_ACC: "1"
+      GO111MODULE: "on"
+      LXD_REMOTE: travis
+      LXD_ADDR: localhost
+      LXD_PORT: 8443
+      LXD_GENERATE_CLIENT_CERTS: "true"
+      LXD_ACCEPT_SERVER_CERTIFICATE: "true"
+      LXD_SCHEME: https
+      LXD_PASSWORD: the-password
+
+    steps:
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Setup LXD from ${{ matrix.channel }} channel
+        run: |
+          sudo snap refresh lxd --channel=${{ matrix.channel }}
+          sudo lxd waitready --timeout 60
+          sudo lxd init --auto --trust-password="$LXD_PASSWORD" --network-port=8443 --network-address='[::]'
+          sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
+
+      - uses: actions/checkout@v2
+      - run: make fmtcheck
+      - run: make vet
+      - run: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
 
 go:
-  - '1.14'
+  - '1.15'
   - master
 
 before_script:
@@ -61,7 +61,7 @@ matrix:
 #  file_glob: true
 #  skip_cleanup: true
 #  on:
-#    go: '1.14'
+#    go: '1.15'
 #    repo: sl1pm4t/terraform-provider-lxd
 #    tags: true
 #    condition: $CHANNEL = "stable"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-lxd/terraform-provider-lxd
 
-go 1.14
+go 1.15
 
 require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0

--- a/lxd/import_resource_lxd_storage_pool_test.go
+++ b/lxd/import_resource_lxd_storage_pool_test.go
@@ -4,19 +4,20 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dustinkirkland/golang-petname"
+	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 func TestAccLxdStoragePool_importBasic(t *testing.T) {
 	poolName := strings.ToLower(petname.Generate(2, "-"))
 	resourceName := "lxd_storage_pool.storage_pool1"
+	source := t.TempDir()
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStoragePool_basic(poolName),
+				Config: testAccStoragePool_basic(poolName, source),
 			},
 
 			{

--- a/lxd/resource_lxd_storage_pool_test.go
+++ b/lxd/resource_lxd_storage_pool_test.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dustinkirkland/golang-petname"
-
+	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
@@ -16,13 +15,14 @@ import (
 func TestAccStoragePool_basic(t *testing.T) {
 	var pool api.StoragePool
 	poolName := strings.ToLower(petname.Generate(2, "-"))
+	source := t.TempDir()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStoragePool_basic(poolName),
+				Config: testAccStoragePool_basic(poolName, source),
 				Check: resource.ComposeTestCheckFunc(
 					testAccStoragePoolExists(t, "lxd_storage_pool.storage_pool1", &pool),
 					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "name", poolName),
@@ -82,14 +82,14 @@ func testAccStoragePoolConfig(pool *api.StoragePool, k, v string) resource.TestC
 	}
 }
 
-func testAccStoragePool_basic(name string) string {
+func testAccStoragePool_basic(name, source string) string {
 	return fmt.Sprintf(`
 resource "lxd_storage_pool" "storage_pool1" {
   name = "%s"
   driver = "dir"
   config = {
-    source = "/mnt"
+    source = "%s"
   }
 }
-	`, name)
+	`, name, source)
 }

--- a/lxd/resource_lxd_volume_container_attach_test.go
+++ b/lxd/resource_lxd_volume_container_attach_test.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dustinkirkland/golang-petname"
-
+	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -17,13 +16,14 @@ func TestAccVolumeContainerAttach_basic(t *testing.T) {
 	poolName := strings.ToLower(petname.Generate(2, "-"))
 	volumeName := strings.ToLower(petname.Generate(2, "-"))
 	containerName := strings.ToLower(petname.Generate(2, "-"))
+	source := t.TempDir()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeContainerAttach_basic(poolName, volumeName, containerName),
+				Config: testAccVolumeContainerAttach_basic(poolName, source, volumeName, containerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVolumeContainerAttachExists(t, "lxd_volume_container_attach.attach1"),
 					resource.TestCheckResourceAttr("lxd_volume_container_attach.attach1", "volume_name", volumeName),
@@ -41,13 +41,14 @@ func TestAccVolumeContainerAttach_deviceName(t *testing.T) {
 	poolName := strings.ToLower(petname.Generate(2, "-"))
 	volumeName := strings.ToLower(petname.Generate(2, "-"))
 	containerName := strings.ToLower(petname.Generate(2, "-"))
+	source := t.TempDir()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVolumeContainerAttach_deviceName(poolName, volumeName, containerName),
+				Config: testAccVolumeContainerAttach_deviceName(poolName, source, volumeName, containerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccVolumeContainerAttachExists(t, "lxd_volume_container_attach.attach1"),
 					resource.TestCheckResourceAttr("lxd_volume_container_attach.attach1", "volume_name", volumeName),
@@ -84,13 +85,13 @@ func testAccVolumeContainerAttachExists(t *testing.T, n string) resource.TestChe
 	}
 }
 
-func testAccVolumeContainerAttach_basic(poolName, volumeName, containerName string) string {
+func testAccVolumeContainerAttach_basic(poolName, source, volumeName, containerName string) string {
 	return fmt.Sprintf(`
 resource "lxd_storage_pool" "pool1" {
   name = "%s"
   driver = "dir"
   config = {
-    source = "/mnt"
+    source = "%s"
   }
 }
 
@@ -111,16 +112,16 @@ resource "lxd_volume_container_attach" "attach1" {
   container_name = "${lxd_container.container1.name}"
   path = "/mnt"
 }
-	`, poolName, volumeName, containerName)
+	`, poolName, source, volumeName, containerName)
 }
 
-func testAccVolumeContainerAttach_deviceName(poolName, volumeName, containerName string) string {
+func testAccVolumeContainerAttach_deviceName(poolName, source, volumeName, containerName string) string {
 	return fmt.Sprintf(`
 resource "lxd_storage_pool" "pool1" {
   name = "%s"
   driver = "dir"
   config = {
-    source = "/mnt"
+    source = "%s"
   }
 }
 
@@ -142,5 +143,5 @@ resource "lxd_volume_container_attach" "attach1" {
   path = "/mnt"
   device_name = "foo"
 }
-	`, poolName, volumeName, containerName)
+	`, poolName, source, volumeName, containerName)
 }


### PR DESCRIPTION
```
All tests involving a storage pool used `/mnt` has the hard-coded source
for the pool. This fails if the hosts `/mnt` is *not* empty. This might
actually not be true and in some cases (e.g. Github Actions VM) it
cannot be changed at all by the developer.

This CL changes all tests to use a new temporary directory, which
*always* is empty as the pool source.

The Go 1.15 update is needed as with 1.15 the testing frameworks
provides a ready to use function to get a temporary directory in a test
case.
```

I've hit this issue locally a few times when having a mount in `/mnt` and on Github Actions. I did include the Go 1.15 upgrade here because it provide such a simple and elegant solution. I've fixed a few wrong indentions within HCL codeblocks too.