### PR TITLE
Fix Ephemeral Container Deletion

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -692,9 +692,14 @@ func resourceLxdContainerDelete(d *schema.ResourceData, meta interface{}) (err e
 		}
 
 		if _, err = stateConf.WaitForState(); err != nil {
+			if err.Error() == "not found" {
+				// Ephemeral containers will be deleted when they are stopped
+				// so we can just return nil here and end the Delete call early.
+				return nil
+			}
+
 			return fmt.Errorf("Error waiting for container (%s) to stop: %s", name, err)
 		}
-
 	}
 
 	op, err := server.DeleteInstance(name)

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -32,6 +32,25 @@ func TestAccContainer_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainer_basicEphemeral(t *testing.T) {
+	var container api.Container
+	containerName := strings.ToLower(petname.Generate(2, "-"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainer_basicEphemeral(containerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccContainerRunning(t, "lxd_container.container1", &container),
+					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccContainer_typeContainer(t *testing.T) {
 	var container api.Container
 	containerName := strings.ToLower(petname.Generate(2, "-"))
@@ -655,6 +674,17 @@ resource "lxd_container" "container1" {
   name = "%s"
   image = "images:alpine/3.12/amd64"
   profiles = ["default"]
+}
+	`, name)
+}
+
+func testAccContainer_basicEphemeral(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_container" "container1" {
+  name = "%s"
+  image = "images:alpine/3.12/amd64"
+  profiles = ["default"]
+  ephemeral = true
 }
 	`, name)
 }


### PR DESCRIPTION
This commit fixes a bug where delete would fail for
ephemeral containers since they are removed when they
are stopped.

For #229 