### PR TITLE
Expose attribute location for created volumes

### DIFF
--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -37,6 +37,12 @@ resource "lxd_volume" "volume1" {
 	[volume config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md).
 	Config settings vary depending on the Storage Pool used.
 
+## Attribute Reference
+
+The following attributes are exported:
+
+* `location` - Name of the node where volume was created.
+
 ## Notes
 
 * Technically, an LXD volume is simply a container or profile device of

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -41,7 +41,7 @@ resource "lxd_volume" "volume1" {
 
 The following attributes are exported:
 
-* `location` - Name of the node where volume was created.
+* `location` - Name of the node where volume was created. It could be useful with LXD in cluster mode.
 
 ## Notes
 

--- a/lxd/resource_lxd_volume.go
+++ b/lxd/resource_lxd_volume.go
@@ -60,7 +60,7 @@ func resourceLxdVolume() *schema.Resource {
 				Computed: true,
 			},
 			"location": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},

--- a/lxd/resource_lxd_volume.go
+++ b/lxd/resource_lxd_volume.go
@@ -59,6 +59,10 @@ func resourceLxdVolume() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
+			"location": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -125,6 +129,7 @@ func resourceLxdVolumeRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("config", newConfig)
 	d.Set("expanded_config", volume.Config)
+	d.Set("location", volume.Location)
 
 	return nil
 }


### PR DESCRIPTION
This is very useful in cluster mode.
If you will create volume without providing target it could be created on any node in the cluster, and you must to create container on the same target to be able use this volume.