### PR TITLE
feat: keep device name

### DIFF
--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -464,6 +464,13 @@ func TestAccContainer_withDevice(t *testing.T) {
 	var container api.Container
 	containerName := strings.ToLower(petname.Generate(2, "-"))
 
+	device := map[string]string{
+		"type":    "nic",
+		"name":    "bar",
+		"nictype": "bridged",
+		"parent":  "lxdbr0",
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -473,6 +480,7 @@ func TestAccContainer_withDevice(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccContainerRunning(t, "lxd_container.container1", &container),
 					resource.TestCheckResourceAttr("lxd_container.container1", "name", containerName),
+					testAccContainerDevice(&container, "foo", device),
 				),
 			},
 		},

--- a/lxd/resource_lxd_profile.go
+++ b/lxd/resource_lxd_profile.go
@@ -119,7 +119,6 @@ func resourceLxdProfileRead(d *schema.ResourceData, meta interface{}) error {
 	for name, lxddevice := range profile.Devices {
 		device := make(map[string]interface{})
 		device["name"] = name
-		delete(lxddevice, "name")
 		device["type"] = lxddevice["type"]
 		delete(lxddevice, "type")
 		device["properties"] = lxddevice


### PR DESCRIPTION
This is required for configurations like this to keep the interface names in the containers:
```
  device {
    name = "eth0"
    type = "nic"

    properties = {
      name    = "eth0"
      nictype = "bridged"
      parent  = "network1"
    }
  }

  device {
    name = "eth1"
    type = "nic"

    properties = {
      name    = "eth1"
      nictype = "bridged"
      parent  = "network2"
    }
  }
```

Without this change, the provider always want to apply changes:
```
      + device {
          + name       = "eth0"
          + properties = {
              + "name"    = "eth0"
              + "nictype" = "bridged"
              + "parent"  = "network1"
            }
          + type       = "nic"
        }
      - device {
          - name       = "eth0" -> null
          - properties = {
              - "nictype" = "bridged"
              - "parent"  = "network1"
            } -> null
          - type       = "nic" -> null
        }
      + device {
          + name       = "eth1"
          + properties = {
              + "name"    = "eth1"
              + "nictype" = "bridged"
              + "parent"  = "network2"
            }
          + type       = "nic"
        }
      - device {
          - name       = "eth1" -> null
          - properties = {
              - "nictype" = "bridged"
              - "parent"  = "network2"
            } -> null
          - type       = "nic" -> null
        }
```