### PR TITLE
Add new device types to the docs

### DIFF
--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -55,6 +55,28 @@ resource "lxd_container" "container1" {
 }
 ```
 
+## Example to proxy/forward ports
+
+```hcl
+resource "lxd_container" "container1" {
+  name = "test2"
+  image = "ubuntu"
+  profiles = ["default"]
+  ephemeral = false
+
+  device {
+    name = "http"
+    type = "proxy"
+    properties = {
+      # Listen on LXD host's TCP port 80
+      listen = "tcp:0.0.0.0:80"
+      # And connect to the container's TCP port 80
+      connect = "tcp:127.0.0.1:80"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 * `remote` - *Optional* - The remote in which the resource will be created. If

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -115,7 +115,7 @@ The `device` block supports:
 * `name` - *Required* - Name of the device.
 
 * `type` - *Required* - Type of the device Must be one of none, disk, nic,
-	unix-char, unix-block, usb, gpu.
+	unix-char, unix-block, usb, gpu, infiniband, proxy.
 
 * `properties`- *Required* - Map of key/value pairs of
 	[device properties](https://github.com/lxc/lxd/blob/master/doc/configuration.md#devices-configuration).

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -58,7 +58,7 @@ The `device` block supports:
 * `name` - *Required* - Name of the device.
 
 * `type` - *Required* - Type of the device Must be one of none, disk, nic,
-	unix-char, unix-block, usb, gpu.
+	unix-char, unix-block, usb, gpu, infiniband, proxy.
 
 * `properties`- *Required* - Map of key/value pairs of
 	[device properties](https://github.com/lxc/lxd/blob/master/doc/configuration.md).


### PR DESCRIPTION
I added a little bit of documentation as well as an example of how to use proxy devices in order to forward ports from the host to a container.