### PR TITLE
Replace 'GetContainerState' with 'GetInstanceState' to support VM imaging

### DIFF
--- a/lxd/resource_lxd_publish_image.go
+++ b/lxd/resource_lxd_publish_image.go
@@ -72,7 +72,7 @@ func resourceLxdPublishImageCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	container := d.Get("container").(string)
-	ct, _, err := dstServer.GetContainerState(container)
+	ct, _, err := dstServer.GetInstanceState(container)
 	if err != nil && err.Error() == "not found" {
 		return err
 	}


### PR DESCRIPTION
Fix for `lxd_publish` following the troubleshooting of https://github.com/terraform-lxd/terraform-provider-lxd/issues/272.