### PR TITLE
migrate from sdk2 testing to terraform-plugin-testing framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
+	github.com/hashicorp/terraform-plugin-testing v1.2.0
 	github.com/lxc/lxd v0.0.0-20191225221339-dfbb18acc0d8
 	github.com/mitchellh/go-homedir v1.1.0
 
@@ -22,7 +23,7 @@ require (
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
-	github.com/hashicorp/go-hclog v1.4.0 // indirect
+	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.8 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 h1:1/D3zfFHttUKaCaGKZ/dR2roBXv0vKbSCnssIldfQdI=
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320/go.mod h1:EiZBMaudVLy8fmjf9Npq1dq9RalhveqZG5w/yz3mHWs=
-github.com/hashicorp/go-hclog v1.4.0 h1:ctuWFGrhFha8BnnzxqeRGidlEcQkDyL5u8J8t5eA11I=
-github.com/hashicorp/go-hclog v1.4.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
+github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
@@ -106,6 +106,8 @@ github.com/hashicorp/terraform-plugin-log v0.8.0 h1:pX2VQ/TGKu+UU1rCay0OlzosNKe4
 github.com/hashicorp/terraform-plugin-log v0.8.0/go.mod h1:1myFrhVsBLeylQzYYEV17VVjtG8oYPRFdaZs7xdW2xs=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1 h1:G9WAfb8LHeCxu7Ae8nc1agZlQOSCUWsb610iAogBhCs=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1/go.mod h1:xcOSYlRVdPLmDUoqPhO9fiO/YCN/l6MGYeTzGt5jgkQ=
+github.com/hashicorp/terraform-plugin-testing v1.2.0 h1:pASRAe6BOZFO4xSGQr9WzitXit0nrQAYDk8ziuRfn9E=
+github.com/hashicorp/terraform-plugin-testing v1.2.0/go.mod h1:+8bp3O7xUb1UtBcdknrGdVRIuTw4b62TYSIgXHqlyew=
 github.com/hashicorp/terraform-registry-address v0.1.0 h1:W6JkV9wbum+m516rCl5/NjKxCyTVaaUBbzYcMzBDO3U=
 github.com/hashicorp/terraform-registry-address v0.1.0/go.mod h1:EnyO2jYO6j29DTHbJcm00E5nQTFeTtyZH3H5ycydQ5A=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/lxd/import_resource_lxd_container_test.go
+++ b/lxd/import_resource_lxd_container_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccContainer_importBasic(t *testing.T) {

--- a/lxd/import_resource_lxd_network_test.go
+++ b/lxd/import_resource_lxd_network_test.go
@@ -3,7 +3,7 @@ package lxd
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestLXDNetwork_importBasic(t *testing.T) {

--- a/lxd/import_resource_lxd_profile_test.go
+++ b/lxd/import_resource_lxd_profile_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestLXDProfile_importBasic(t *testing.T) {

--- a/lxd/import_resource_lxd_storage_pool_test.go
+++ b/lxd/import_resource_lxd_storage_pool_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccLxdStoragePool_importBasic(t *testing.T) {

--- a/lxd/provider_test.go
+++ b/lxd/provider_test.go
@@ -6,8 +6,8 @@ import (
 
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 var testAccProviders map[string]*schema.Provider

--- a/lxd/resource_lxd_cached_image_test.go
+++ b/lxd/resource_lxd_cached_image_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/dustinkirkland/golang-petname"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"strconv"
 

--- a/lxd/resource_lxd_container_file_test.go
+++ b/lxd/resource_lxd_container_file_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/dustinkirkland/golang-petname"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/lxc/lxd/shared/api"
 
 	"github.com/lxc/lxd/client"

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/lxc/lxd/shared/api"
 )

--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/lxc/lxd/shared/api"
 )

--- a/lxd/resource_lxd_profile_test.go
+++ b/lxd/resource_lxd_profile_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/dustinkirkland/golang-petname"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/lxc/lxd/shared/api"
 )

--- a/lxd/resource_lxd_project_test.go
+++ b/lxd/resource_lxd_project_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/dustinkirkland/golang-petname"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/lxc/lxd/shared/api"
 )

--- a/lxd/resource_lxd_publish_image_test.go
+++ b/lxd/resource_lxd_publish_image_test.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dustinkirkland/golang-petname"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/lxc/lxd/shared/api"
 )

--- a/lxd/resource_lxd_snapshot_test.go
+++ b/lxd/resource_lxd_snapshot_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/lxc/lxd/shared/api"
 )
 

--- a/lxd/resource_lxd_storage_pool_test.go
+++ b/lxd/resource_lxd_storage_pool_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/lxc/lxd/shared/api"
 )

--- a/lxd/resource_lxd_volume_container_attach_test.go
+++ b/lxd/resource_lxd_volume_container_attach_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccVolumeContainerAttach_basic(t *testing.T) {

--- a/lxd/resource_lxd_volume_test.go
+++ b/lxd/resource_lxd_volume_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/lxc/lxd/shared/api"
 )


### PR DESCRIPTION
https://developer.hashicorp.com/terraform/plugin/testing/migrating

This is the current recommended testing framework. If and when an effort is undertaken to migrate the newer Plugin Framework, this will be a requirement. Either way, this was a relatively simple migration.