### PR TITLE
Explicitly set provider certificate defaults to false

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,12 +69,13 @@ The following arguments are supported:
 * `generate_client_certificates` - *Optional* - Automatically generate the LXD
 	client certificate if it does not exist. Valid values are `true` and `false`.
 	This can also be set with the `LXD_GENERATE_CLIENT_CERTS` Environment
-	variable.
+	variable. Defaults to `false`.
 
 * `accept_remote_certificate` - *Optional* - Automatically accept the LXD
 	remote's certificate. Valid values are `true` and `false`. If this is not set
 	to `true`, you must accept the certificate out of band of Terraform. This can
 	also be set with the `LXD_ACCEPT_SERVER_CERTIFICATE` environment variable.
+  Defaults to `false`
 
 * `refresh_interval` - *Optional* - How often to poll during state change.
 	Defaults to "10s", or 10 seconds. Valid values are a Go-style parsable time

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -168,14 +168,14 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: descriptions["lxd_generate_client_certs"],
-				DefaultFunc: schema.EnvDefaultFunc("LXD_GENERATE_CLIENT_CERTS", ""),
+				DefaultFunc: schema.EnvDefaultFunc("LXD_GENERATE_CLIENT_CERTS", "false"),
 			},
 
 			"accept_remote_certificate": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: descriptions["lxd_accept_remote_certificate"],
-				DefaultFunc: schema.EnvDefaultFunc("LXD_ACCEPT_SERVER_CERTIFICATE", ""),
+				DefaultFunc: schema.EnvDefaultFunc("LXD_ACCEPT_SERVER_CERTIFICATE", "false"),
 			},
 
 			"refresh_interval": {


### PR DESCRIPTION
Avoid type warnings shown below. [Rendered version of doc](https://github.com/adamcstephens/terraform-provider-lxd/blob/provider-defaults/docs/index.md)

These two settings already default to false and are the safer defaults.

```
│ Warning: provider set empty string as default value for bool accept_remote_certificate
│ 
│   with provider["registry.terraform.io/terraform-lxd/lxd"],
│   on test.tf line 9, in provider "lxd":
│    9: provider "lxd" {
│ 
╵
╷
│ Warning: provider set empty string as default value for bool generate_client_certificates
│ 
│   with provider["registry.terraform.io/terraform-lxd/lxd"],
│   on test.tf line 9, in provider "lxd":
│    9: provider "lxd" {
│ 
╵
```