### PR TITLE
Update LXD project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ LXD Resource provider for Terraform
 ## Prerequisites
 
 * [Terraform](http://terraform.io)
-* [LXD](https://linuxcontainers.org/lxd)
+* [LXD](https://ubuntu.com/lxd)
 
 ## Installation
 

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -2,7 +2,7 @@
 
 Manages an LXD container.
 
-A container can take a number of configuration and device options. A full reference can be found [here](https://github.com/lxc/lxd/blob/master/doc/configuration.md).
+A container can take a number of configuration and device options. A full reference can be found [here](https://documentation.ubuntu.com/lxd/en/latest/reference/instance_options/).
 
 ## Basic Example
 
@@ -96,10 +96,10 @@ resource "lxd_container" "container1" {
 	Valid values are `true` and `false`. Defaults to `false`.
 
 * `config` - *Optional* - Map of key/value pairs of
-	[container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md#container-configuration).
+	[container config settings](https://documentation.ubuntu.com/lxd/en/latest/reference/instance_options/).
 
 * `limits` - *Optional* - Map of key/value pairs that define the
-	[container resources limits](https://github.com/lxc/lxd/blob/master/doc/containers.md).
+	[container resources limits](https://documentation.ubuntu.com/lxd/en/latest/reference/instance_options/#resource-limits).
 
 * `device` - *Optional* - Device definition. See reference below.
 
@@ -120,7 +120,7 @@ The `device` block supports:
 	unix-char, unix-block, usb, gpu, infiniband, proxy.
 
 * `properties`- *Required* - Map of key/value pairs of
-	[device properties](https://github.com/lxc/lxd/blob/master/doc/configuration.md#devices-configuration).
+	[device properties](https://documentation.ubuntu.com/lxd/en/latest/reference/devices/).
 
 The `file` block supports:
 

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -5,7 +5,7 @@ Manages an LXD network.
 You must be using LXD 2.3 or later. See
 [this](https://www.stgraber.org/2016/10/27/network-management-with-lxd-2-3/)
 blog post for details about LXD networking and the
-[configuration reference](https://github.com/lxc/lxd/blob/master/doc/configuration.md)
+[configuration reference](https://documentation.ubuntu.com/lxd/en/latest/explanation/networks/)
 for all network details.
 
 ## Example Usage
@@ -196,7 +196,7 @@ for more details on how to create a network in clustered mode.
   is created.
 
 * `config` - *Optional* - Map of key/value pairs of
-	[network config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md).
+	[network config settings](https://documentation.ubuntu.com/lxd/en/latest/networks/).
 
 * `project` - *Optional* - Name of the project where the network will be created.
 

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -49,7 +49,7 @@ resource "lxd_container" "test1" {
 * `name` - *Required* - Name of the container.
 
 * `config` - *Optional* - Map of key/value pairs of
-	[container config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md).
+	[container config settings](https://documentation.ubuntu.com/lxd/en/latest/reference/instance_options/).
 
 * `device` - *Optional* - Device definition. See reference below.
 
@@ -63,7 +63,7 @@ The `device` block supports:
 	unix-char, unix-block, usb, gpu, infiniband, proxy.
 
 * `properties`- *Required* - Map of key/value pairs of
-	[device properties](https://github.com/lxc/lxd/blob/master/doc/configuration.md).
+	[device properties](https://documentation.ubuntu.com/lxd/en/latest/reference/devices/).
 
 ## Importing
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -29,6 +29,6 @@ resource "lxd_container" "container" {
 
 * `description` - *Optional* - Description of the project. 
 
-* `config` - *Optional* - Map of key/value pairs of [project config settings](https://github.com/lxc/lxd/blob/master/doc/projects.md).
+* `config` - *Optional* - Map of key/value pairs of [project config settings](https://documentation.ubuntu.com/lxd/en/latest/reference/projects/).
 
 * `target` - *Optional* - Specify a target node in a cluster. 

--- a/docs/resources/storage_pool.md
+++ b/docs/resources/storage_pool.md
@@ -70,7 +70,7 @@ for more details on how to create a storage pool in clustered mode.
 	`btrfs`, or `zfs`.
 
 * `config` - *Optional* - Map of key/value pairs of
-	[storage pool config settings](https://github.com/lxc/lxd/blob/master/doc/configuration.md).
+	[storage pool config settings](https://documentation.ubuntu.com/lxd/en/latest/reference/storage_drivers/).
 	Config settings vary from driver to driver.
 
 * `project` - *Optional* - Name of the project where the storage pool will be stored.

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -30,7 +30,7 @@ type lxdProvider struct {
 	// LXDConfig is the converted form of terraformLXDConfig
 	// in LXD's native data structure. This is lazy-loaded / created
 	// only when a connection to an LXD remote/server happens.
-	// https://github.com/lxc/lxd/blob/master/lxc/config/config.go
+	// https://github.com/canonical/lxd/blob/main/lxc/config/config.go
 	LXDConfig *lxd_config.Config
 
 	// lxdClientMap is a map of LXD client connections to LXD

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -425,7 +425,7 @@ func resourceLxdContainerRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	name := d.Id()
-	// https://github.com/lxc/lxd/blob/master/client/lxd_instances.go
+	// https://github.com/canonical/lxd/blob/main/client/lxd_instances.go
 	container, _, err := server.GetInstance(name)
 	if err != nil {
 		return err
@@ -567,7 +567,7 @@ func resourceLxdContainerUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	// Copy the current container configuration to the updatable container struct.
-	// https://github.com/lxc/lxd/blob/3df4aa84e8a86f5186b312243dc212ff8da06941/shared/api/instance.go#L136
+	// https://github.com/canonical/lxd/blob/3df4aa84e8a86f5186b312243dc212ff8da06941/shared/api/instance.go#L136
 	newContainer := api.InstancePut{
 		Architecture: ct.Architecture,
 		Config:       ct.Config,

--- a/lxd/resource_lxd_project.go
+++ b/lxd/resource_lxd_project.go
@@ -59,12 +59,12 @@ func resourceLxdProjectCreate(d *schema.ResourceData, meta interface{}) error {
 	config := resourceLxdConfigMap(d.Get("config"))
 
 	log.Printf("Attempting to create project %s", name)
-	// https://github.com/lxc/lxd/blob/master/shared/api/project.go
+	// https://github.com/canonical/lxd/blob/main/shared/api/project.go
 	req := api.ProjectsPost{Name: name}
 	req.Config = config
 	req.Description = description
 
-	// NOTE: https://github.com/lxc/lxd/blob/master/client/interfaces.go
+	// NOTE: https://github.com/canonical/lxd/blob/main/client/interfaces.go
 	if err := server.CreateProject(req); err != nil {
 		return err
 	}

--- a/lxd/shared.go
+++ b/lxd/shared.go
@@ -314,7 +314,7 @@ func containerDeleteFile(server lxd.ContainerServer, container string, targetFil
 	return nil
 }
 
-// recursiveMkdir was copied almost as-is from github.com/lxc/lxd/lxc/file.go
+// recursiveMkdir was copied almost as-is from github.com/canonical/lxd/blob/main/lxc/file.go
 func recursiveMkdir(d lxd.ContainerServer, container string, p string, mode os.FileMode, uid int64, gid int64) error {
 	/* special case, every container has a /, we don't need to do anything */
 	if p == "/" {


### PR DESCRIPTION
LXD project has been recently moved from Linux containers to Canonical (see [project announcement](https://linuxcontainers.org/lxd/)).

This PR updates project references in documentation and code comments.