### PR TITLE
Format code examples in documentation

### DIFF
--- a/docs/resources/cached_image.md
+++ b/docs/resources/cached_image.md
@@ -12,7 +12,7 @@ resource "lxd_cached_image" "xenial" {
 
 resource "lxd_container" "test1" {
   name      = "test1"
-  image     = "${lxd_cached_image.xenial.fingerprint}"
+  image     = lxd_cached_image.xenial.fingerprint
   ephemeral = false
 }
 ```

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -26,7 +26,7 @@ resource "lxd_container" "test1" {
 
 ```hcl
 resource "lxd_storage_pool" "pool1" {
-  name = "mypool"
+  name   = "mypool"
   driver = "dir"
   config = {
     source = "/var/lib/lxd/storage-pools/mypool"
@@ -35,21 +35,21 @@ resource "lxd_storage_pool" "pool1" {
 
 resource "lxd_volume" "volume1" {
   name = "myvolume"
-  pool = "${lxd_storage_pool.pool1.name}"
+  pool = lxd_storage_pool.pool1.name
 }
 
 resource "lxd_container" "container1" {
-  name = "%s"
-  image = "ubuntu"
+  name     = "test"
+  image    = "ubuntu"
   profiles = ["default"]
 
   device {
     name = "volume1"
     type = "disk"
     properties = {
-      path = "/mount/point/in/container"
+      path   = "/mount/point/in/container"
       source = "${lxd_volume.volume1.name}"
-      pool = "${lxd_storage_pool.pool1.name}"
+      pool   = "${lxd_storage_pool.pool1.name}"
     }
   }
 }
@@ -59,9 +59,9 @@ resource "lxd_container" "container1" {
 
 ```hcl
 resource "lxd_container" "container1" {
-  name = "test2"
-  image = "ubuntu"
-  profiles = ["default"]
+  name      = "test2"
+  image     = "ubuntu"
+  profiles  = ["default"]
   ephemeral = false
 
   device {
@@ -170,8 +170,8 @@ To specify an interface, do the following:
 
 ```hcl
 resource "lxd_container" "container1" {
-  name = "container1"
-  image = "images:alpine/3.5/amd64"
+  name     = "container1"
+  image    = "images:alpine/3.5/amd64"
   profiles = ["default"]
 
   config = {

--- a/docs/resources/container_file.md
+++ b/docs/resources/container_file.md
@@ -16,7 +16,7 @@ resource "lxd_container" "test1" {
 }
 
 resource "lxd_container_file" "file1" {
-  container_name     = "${lxd_container.test1.name}"
+  container_name     = lxd_container.test1.name
   target_file        = "/foo/bar.txt"
   source             = "/path/to/local/file"
   create_directories = true

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -151,12 +151,12 @@ the actual network:
 
 ```hcl
 resource "lxd_network" "my_network_node1" {
-  name = "my_network"
+  name   = "my_network"
   target = "node1"
 }
 
 resource "lxd_network" "my_network_node2" {
-  name = "my_network"
+  name   = "my_network"
   target = "node2"
 }
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -9,16 +9,16 @@ resource "lxd_project" "project" {
   name        = "project1"
   description = "Terraform provider example project"
   config = {
-	"features.storage.volumes" = false
-	"features.images" = false
-	"features.profiles" = false
-	"features.storage.buckets" = false
+    "features.storage.volumes" = false
+    "features.images"          = false
+    "features.profiles"        = false
+    "features.storage.buckets" = false
   }
 }
 
 resource "lxd_container" "container" {
-  name = "container1"
-  image = "images:alpine/3.16/amd64"
+  name    = "container1"
+  image   = "images:alpine/3.16/amd64"
   project = lxd_project.project.name
 }
 ```

--- a/docs/resources/publish_image.md
+++ b/docs/resources/publish_image.md
@@ -11,20 +11,19 @@ resource "lxd_cached_image" "xenial" {
 }
 
 resource "lxd_container" "test1" {
-  name      = "test1"
-  image     = "${lxd_cached_image.xenial.fingerprint}"
-  profiles  = ["default"]
+  name     = "test1"
+  image    = lxd_cached_image.xenial.fingerprint
+  profiles = ["default"]
 
   start_container = false
 }
 
 resource "lxd_publish_image" "test1" {
-  depends_on = [ lxd_container.test1 ]
+  depends_on = [lxd_container.test1]
 
   container = "test1"
-  aliases   = [ "test1_img" ]
+  aliases   = ["test1_img"]
 }
-
 ```
 
 ## Argument Reference

--- a/docs/resources/snapshot.md
+++ b/docs/resources/snapshot.md
@@ -6,7 +6,7 @@ Manages a snapshot of an LXD container.
 
 ```hcl
 resource "lxd_snapshot" "snap1" {
-  container_name = "${lxd_container.container1.name}"
+  container_name = lxd_container.container1.name
   name           = "snap1"
 }
 ```

--- a/docs/resources/storage_pool.md
+++ b/docs/resources/storage_pool.md
@@ -8,7 +8,7 @@ Manages an LXD storage pool.
 
 ```hcl
 resource "lxd_storage_pool" "pool1" {
-  name = "mypool"
+  name   = "mypool"
   driver = "dir"
   config = {
     source = "/var/lib/lxd/storage-pools/mypool"
@@ -26,7 +26,7 @@ actual pool
 resource "lxd_storage_pool" "mypool_node1" {
   target = "node1"
 
-  name = "mypool"
+  name   = "mypool"
   driver = "dir"
   config = {
     source = "/var/lib/lxd/storage-pools/mypool"
@@ -36,7 +36,7 @@ resource "lxd_storage_pool" "mypool_node1" {
 resource "lxd_storage_pool" "mypool_node2" {
   target = "node2"
 
-  name = "mypool"
+  name   = "mypool"
   driver = "dir"
   config = {
     source = "/var/lib/lxd/storage-pools/mypool"
@@ -45,11 +45,11 @@ resource "lxd_storage_pool" "mypool_node2" {
 
 resource "lxd_storage_pool" "mypool" {
   depends_on = [
-    "lxd_storage_pool.mypool_node1",
-    "lxd_storage_pool.mypool_node2",
+    lxd_storage_pool.mypool_node1,
+    lxd_storage_pool.mypool_node2,
   ]
 
-  name = "mypool"
+  name   = "mypool"
   driver = "dir"
 }
 ```

--- a/docs/resources/volume_container_attach.md
+++ b/docs/resources/volume_container_attach.md
@@ -20,7 +20,7 @@ resource "lxd_storage_pool" "pool1" {
 
 resource "lxd_volume" "volume1" {
   name = "myvolume"
-  pool = "${lxd_storage_pool.pool1.name}"
+  pool = lxd_storage_pool.pool1.name
 }
 
 resource "lxd_container" "container1" {
@@ -30,9 +30,9 @@ resource "lxd_container" "container1" {
 }
 
 resource "lxd_volume_container_attach" "attach1" {
-  pool           = "${lxd_storage_pool.pool1.name}"
-  volume_name    = "${lxd_volume.volume1.name}"
-  container_name = "${lxd_container.container1.name}"
+  pool           = lxd_storage_pool.pool1.name
+  volume_name    = lxd_volume.volume1.name
+  container_name = lxd_container.container1.name
   path           = "/tmp"
 }
 ```

--- a/docs/resources/volume_copy.md
+++ b/docs/resources/volume_copy.md
@@ -6,7 +6,7 @@ Copies an existing LXD volume.
 
 ```hcl
 resource "lxd_storage_pool" "pool1" {
-  name = "mypool"
+  name   = "mypool"
   driver = "dir"
   config = {
     source = "/var/lib/lxd/storage-pools/mypool"
@@ -15,14 +15,14 @@ resource "lxd_storage_pool" "pool1" {
 
 resource "lxd_volume" "volume1" {
   name = "myvolume"
-  pool = "${lxd_storage_pool.pool1.name}"
+  pool = lxd_storage_pool.pool1.name
 }
 
 resource "lxd_volume_copy" "volume1_copy" {
-  name = "myvolume_copy"
-  pool = "${lxd_storage_pool.pool1.name}"
-  source_pool = "${lxd_storage_pool.pool1.name}"
-  source_name = "${lxd_volume.volume1.name}"
+  name        = "myvolume_copy"
+  pool        = lxd_storage_pool.pool1.name
+  source_pool = lxd_storage_pool.pool1.name
+  source_name = lxd_volume.volume1.name
 }
 ```
 


### PR DESCRIPTION
This PR formats code examples in the documentation (using `terraform fmt`).