### PR TITLE
Remove the storage pool driver validate function

### DIFF
--- a/docs/resources/storage_pool.md
+++ b/docs/resources/storage_pool.md
@@ -66,8 +66,7 @@ for more details on how to create a storage pool in clustered mode.
 
 * `name`   - *Required* - Name of the storage pool.
 
-* `driver` - *Required* - Storage Pool driver. Must be one of `dir`, `lvm`,
-	`btrfs`, or `zfs`.
+* `driver` - *Required* - Storage Pool driver.
 
 * `config` - *Optional* - Map of key/value pairs of
 	[storage pool config settings](https://documentation.ubuntu.com/lxd/en/latest/reference/storage_drivers/).

--- a/lxd/resource_lxd_storage_pool.go
+++ b/lxd/resource_lxd_storage_pool.go
@@ -1,7 +1,6 @@
 package lxd
 
 import (
-	"fmt"
 	"log"
 	"strings"
 
@@ -44,14 +43,6 @@ func resourceLxdStoragePool() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if value != "dir" && value != "lvm" && value != "btrfs" && value != "zfs" {
-						errors = append(errors, fmt.Errorf(
-							"Only dir, lvm, btrfs, and zfs are supported values for 'driver'"))
-					}
-					return
-				},
 			},
 
 			"config": {


### PR DESCRIPTION
LXD supports more drivers than this checks for. Let the API return an error instead of explicitly checking for this.

This should address and close #250.