### PR TITLE
Update actions, go modules, and enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      hashicorp:
+        patterns:
+          - github.com/hashicorp/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,28 +20,28 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: '1.20'
       -
         name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v5
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.20"
+          - '1.20'
         channel:
           - latest/stable
           - latest/candidate
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -36,7 +36,7 @@ jobs:
           sudo lxd init --auto --trust-password="$LXD_PASSWORD" --network-port=8443 --network-address='[::]'
           sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: make fmtcheck
       - run: make vet
       - run: make test


### PR DESCRIPTION
I noticed some actions warnings, and had been exploring dependabot already. This won't update the lxd client unfortunately, but I'll need to investigate that another time.