### PR TITLE
Support config.cloud-init keys

### DIFF
--- a/lxd/resource_lxd_instance.go
+++ b/lxd/resource_lxd_instance.go
@@ -460,6 +460,8 @@ func resourceLxdInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			limits[strings.TrimPrefix(k, "limits.")] = v
 		case strings.HasPrefix(k, "boot."):
 			config[k] = v
+		case strings.HasPrefix(k, "cloud-init."):
+			config[k] = v
 		case strings.HasPrefix(k, "environment."):
 			config[k] = v
 		case strings.HasPrefix(k, "raw."):

--- a/lxd/resource_lxd_instance_test.go
+++ b/lxd/resource_lxd_instance_test.go
@@ -163,6 +163,20 @@ func TestAccInstance_updateConfig(t *testing.T) {
 					testAccInstanceConfig(&instance, "user.user-data", "#cloud-config"),
 				),
 			},
+			{
+				Config: testAccInstance_updateConfig3(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccInstanceRunning(t, "lxd_instance.instance1", &instance),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "config.cloud-init.vendor-data", "#cloud-config"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "config.user.dummy", "5"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "config.user.user-data", "#cloud-config"),
+					testAccInstanceConfigAbsent(&instance, "boot.autostart"),
+					testAccInstanceConfig(&instance, "cloud-init.vendor-data", "#cloud-config"),
+					testAccInstanceConfig(&instance, "user.dummy", "5"),
+					testAccInstanceConfig(&instance, "user.user-data", "#cloud-config"),
+				),
+			},
 		},
 	})
 }
@@ -886,6 +900,21 @@ resource "lxd_instance" "instance1" {
   profiles = ["default"]
   config = {
 	"user.dummy" = 5
+    "user.user-data" = "#cloud-config"
+  }
+}
+	`, name)
+}
+
+func testAccInstance_updateConfig3(name string) string {
+	return fmt.Sprintf(`
+resource "lxd_instance" "instance1" {
+  name = "%s"
+  image = "images:alpine/3.16"
+  profiles = ["default"]
+  config = {
+    "cloud-init.vendor-data" = "#cloud-config"
+    "user.dummy" = 5
     "user.user-data" = "#cloud-config"
   }
 }


### PR DESCRIPTION
This avoid triggering repeated changes on every run even when the `config.cloud-init` keys do not change.