### PR TITLE
Fix not found error checks

### DIFF
--- a/lxd/errors.go
+++ b/lxd/errors.go
@@ -2,8 +2,20 @@ package lxd
 
 import (
 	"errors"
+	"net/http"
+
+	"github.com/canonical/lxd/shared/api"
 )
 
 var errNetworksNotImplemented = errors.New("This LXD server does not support " +
 	"the creation of networks. You must be running LXD 2.3 or later for this " +
 	"feature.")
+
+func isNotFoundError(err error) bool {
+	// For LXD versions below "4.0".
+	if err.Error() == "No such object" || err.Error() == "not found" {
+		return true
+	}
+
+	return api.StatusErrorCheck(err, http.StatusNotFound)
+}

--- a/lxd/resource_lxd_cached_image.go
+++ b/lxd/resource_lxd_cached_image.go
@@ -260,7 +260,7 @@ func resourceLxdCachedImageExists(d *schema.ResourceData, meta interface{}) (boo
 
 	_, _, err = server.GetImage(id.fingerprint)
 	if err != nil {
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			return false, nil
 		}
 		return false, err
@@ -285,7 +285,7 @@ func resourceLxdCachedImageRead(d *schema.ResourceData, meta interface{}) error 
 
 	img, _, err := server.GetImage(id.fingerprint)
 	if err != nil {
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			d.SetId("")
 			return nil
 		}

--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -775,7 +775,7 @@ func resourceLxdContainerExists(d *schema.ResourceData, meta interface{}) (exist
 	exists = false
 	name := d.Id()
 	ct, _, err := server.GetInstanceState(name)
-	if err != nil && err.Error() == "not found" {
+	if err != nil && isNotFoundError(err) {
 		err = nil
 	}
 	if err == nil && ct != nil {

--- a/lxd/resource_lxd_container_file.go
+++ b/lxd/resource_lxd_container_file.go
@@ -223,7 +223,7 @@ func resourceLxdContainerFileExists(d *schema.ResourceData, meta interface{}) (e
 		// If the container could not be found, then the file
 		// can't exist. Ignore the error and return with exists
 		// set to false.
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			err = nil
 			return
 		}
@@ -236,7 +236,7 @@ func resourceLxdContainerFileExists(d *schema.ResourceData, meta interface{}) (e
 	if err != nil {
 		// If the file could not be found, then it doesn't exist.
 		// Ignore the error and return with exists set to false.
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			err = nil
 			return
 		}

--- a/lxd/resource_lxd_instance.go
+++ b/lxd/resource_lxd_instance.go
@@ -773,11 +773,12 @@ func resourceLxdInstanceExists(d *schema.ResourceData, meta interface{}) (exists
 
 	exists = false
 	name := d.Id()
-	ct, _, err := server.GetInstanceState(name)
-	if err != nil && err.Error() == "not found" {
+	state, _, err := server.GetInstanceState(name)
+	if err != nil && isNotFoundError(err) {
 		err = nil
 	}
-	if err == nil && ct != nil {
+
+	if err == nil && state != nil {
 		exists = true
 	}
 
@@ -809,16 +810,16 @@ func resourceLxdInstanceImport(d *schema.ResourceData, meta interface{}) ([]*sch
 		server = server.UseProject(project)
 	}
 
-	ct, _, err := server.GetInstanceState(name)
+	state, _, err := server.GetInstanceState(name)
 	if err != nil {
 		return nil, err
 	}
 
-	if ct == nil {
+	if state == nil {
 		return nil, fmt.Errorf("Unable to get instance state")
 	}
 
-	log.Printf("[DEBUG] Import instance state %#v", ct)
+	log.Printf("[DEBUG] Import instance state %#v", state)
 	d.SetId(name)
 	d.Set("name", name)
 

--- a/lxd/resource_lxd_instance_file.go
+++ b/lxd/resource_lxd_instance_file.go
@@ -222,7 +222,7 @@ func resourceLxdInstanceFileExists(d *schema.ResourceData, meta interface{}) (ex
 		// If the instance could not be found, then the file
 		// can't exist. Ignore the error and return with exists
 		// set to false.
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			err = nil
 			return
 		}
@@ -235,7 +235,7 @@ func resourceLxdInstanceFileExists(d *schema.ResourceData, meta interface{}) (ex
 	if err != nil {
 		// If the file could not be found, then it doesn't exist.
 		// Ignore the error and return with exists set to false.
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			err = nil
 			return
 		}

--- a/lxd/resource_lxd_network.go
+++ b/lxd/resource_lxd_network.go
@@ -139,7 +139,7 @@ func resourceLxdNetworkRead(d *schema.ResourceData, meta interface{}) error {
 
 	network, _, err := server.GetNetwork(name)
 	if err != nil {
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
@@ -225,7 +225,7 @@ func resourceLxdNetworkDelete(d *schema.ResourceData, meta interface{}) (err err
 	name := d.Id()
 
 	err = server.DeleteNetwork(name)
-	if err != nil && err.Error() == "not found" {
+	if err != nil && isNotFoundError(err) {
 		err = nil
 	}
 
@@ -249,7 +249,7 @@ func resourceLxdNetworkExists(d *schema.ResourceData, meta interface{}) (exists 
 	exists = false
 
 	v, _, err := server.GetNetwork(name)
-	if err != nil && err.Error() == "not found" {
+	if err != nil && isNotFoundError(err) {
 		err = nil
 	}
 	if err == nil && v != nil {

--- a/lxd/resource_lxd_publish_image.go
+++ b/lxd/resource_lxd_publish_image.go
@@ -98,7 +98,7 @@ func resourceLxdPublishImageCreate(d *schema.ResourceData, meta interface{}) err
 
 	container := d.Get("container").(string)
 	ct, _, err := dstServer.GetInstanceState(container)
-	if err != nil && err.Error() == "not found" {
+	if err != nil && isNotFoundError(err) {
 		return err
 	}
 
@@ -247,7 +247,7 @@ func resourceLxdPublishImageRead(d *schema.ResourceData, meta interface{}) error
 
 	img, _, err := server.GetImage(id.fingerprint)
 	if err != nil {
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			d.SetId("")
 			return nil
 		}

--- a/lxd/resource_lxd_snapshot.go
+++ b/lxd/resource_lxd_snapshot.go
@@ -136,7 +136,7 @@ func resourceLxdSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 
 	snap, _, err := server.GetInstanceSnapshot(snapID.container, snapID.snapshot)
 	if err != nil {
-		if err.Error() == "not found" {
+		if isNotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
@@ -187,7 +187,7 @@ func resourceLxdSnapshotExists(d *schema.ResourceData, meta interface{}) (bool, 
 
 	snap, _, err := server.GetInstanceSnapshot(snapID.container, snapID.snapshot)
 
-	if err != nil && err.Error() == "not found" {
+	if err != nil && isNotFoundError(err) {
 		err = nil
 	}
 	if err == nil && snap != nil {

--- a/lxd/resource_lxd_storage_pool.go
+++ b/lxd/resource_lxd_storage_pool.go
@@ -131,7 +131,7 @@ func resourceLxdStoragePoolRead(d *schema.ResourceData, meta interface{}) error 
 
 	pool, _, err := server.GetStoragePool(name)
 	if err != nil {
-		if err.Error() == "No such object" {
+		if isNotFoundError(err) {
 			d.SetId("")
 			return nil
 		}
@@ -229,7 +229,7 @@ func resourceLxdStoragePoolDelete(d *schema.ResourceData, meta interface{}) (err
 	name := d.Id()
 
 	err = server.DeleteStoragePool(name)
-	if err != nil && err.Error() == "No such object" {
+	if err != nil && isNotFoundError(err) {
 		err = nil
 	}
 
@@ -257,7 +257,7 @@ func resourceLxdStoragePoolExists(d *schema.ResourceData, meta interface{}) (exi
 	exists = false
 
 	v, _, err := server.GetStoragePool(name)
-	if err != nil && err.Error() == "No such object" {
+	if err != nil && isNotFoundError(err) {
 		err = nil
 	}
 


### PR DESCRIPTION
Currently, when the provider retrieves LXD storage pool (or tries to delete it), it checks whether an error equals to `No such object`. In such case it detects that the storage pool does not exist and an error is not reported.

However, LXD returns different error in such cases (https://github.com/canonical/lxd/blob/7f46f71133411a66be20fce1a2b92de3923db705/lxd/db/storage_pools.go#L666) - `Storage pool not found`.

