### PR TITLE
Update CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: Test
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - '1.20'
+          - '1.21'
         channel:
           - latest/stable
           - latest/candidate


### PR DESCRIPTION
I initially planned to test `4.0/stable` and `5.0/stable` LXD snap channels but many tests are failing due to unsupported feature. Since @MusicDin is working on some API support detection bits, I'll revisit that later on.