### PR TITLE
Add acceptance test prechecks 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/canonical/lxd v0.0.0-20230721084020-fa2ec65c7e2e
 	github.com/dustinkirkland/golang-petname v0.0.0-20230626224747-e794b9370d49
+	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
 	github.com/hashicorp/terraform-plugin-testing v1.4.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -34,7 +35,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.10 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hc-install v0.5.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect

--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -71,13 +71,11 @@ func TestAccContainer_typeContainer(t *testing.T) {
 }
 
 func TestAccContainer_typeVirtualMachine(t *testing.T) {
-	t.Skip("Travis CI environment does not support virtualization")
-
 	var container api.Container
 	containerName := strings.ToLower(petname.Generate(2, "-"))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckVirtualization(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -509,13 +507,11 @@ func TestAccContainer_isStopped(t *testing.T) {
 }
 
 func TestAccContainer_target(t *testing.T) {
-	t.Skip("Test environment does not support clustering yet")
-
 	var container api.Container
 	containerName := strings.ToLower(petname.Generate(2, "-"))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckClustering(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/lxd/resource_lxd_instance_test.go
+++ b/lxd/resource_lxd_instance_test.go
@@ -71,13 +71,11 @@ func TestAccInstance_typeInstance(t *testing.T) {
 }
 
 func TestAccInstance_typeVirtualMachine(t *testing.T) {
-	t.Skip("Travis CI environment does not support virtualization")
-
 	var instance api.Instance
 	instanceName := strings.ToLower(petname.Generate(2, "-"))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckVirtualization(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -515,7 +513,7 @@ func TestAccInstance_target(t *testing.T) {
 	instanceName := strings.ToLower(petname.Generate(2, "-"))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckClustering(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/lxd/utils.go
+++ b/lxd/utils.go
@@ -1,0 +1,22 @@
+package lxd
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+)
+
+// CheckVersion checks whether the version satisfies the provided version constraints.
+func CheckVersion(versionString string, versionConstraint string) (bool, error) {
+	ver, err := version.NewVersion(versionString)
+	if err != nil {
+		return false, fmt.Errorf("Unable to parse version %q: %v", versionString, err)
+	}
+
+	constraint, err := version.NewConstraint(versionConstraint)
+	if err != nil {
+		return false, fmt.Errorf("Unable to parse version constraint %q: %v", versionConstraint, err)
+	}
+
+	return constraint.Check(ver), nil
+}


### PR DESCRIPTION
This PR adds 4 acceptance test prechecks that skip the test execution if certain condition is not satisfied.
- `testAccPreCheckLxdVersion` skips the test if LXD does not satisfy the version constraint.
- `testAccPreCheckAPIExtensions` skips the test if LXD does not support all the required extensions.
- `testAccPreCheckClustering` skips the test if LXD does not run in a clustered mode.
- `testAccPreCheckVirtualization` skips the test if LXD does not support virtualization.

This is required by @simondeziel to be able to properly configure tests for older LXD versions.