### PR TITLE
Use unix as default remote scheme instead of https

### DIFF
--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -118,7 +118,7 @@ func Provider() *schema.Provider {
 							Optional:     true,
 							Description:  descriptions["lxd_remote_scheme"],
 							ValidateFunc: validateLxdRemoteScheme,
-							Default:      "https",
+							Default:      "unix",
 						},
 					},
 				},


### PR DESCRIPTION
Currently, [provider's docs](https://registry.terraform.io/providers/terraform-lxd/lxd/latest/docs#scheme) state that if remote scheme is not set, `unix` is used by default, which is not true. 

This PR changes the default remote scheme from `https` to `unix`. However, we can also fix the docs instead.

@adamcstephens What are your thoughts?