### PR TITLE
Use test precheck to detect if LXD is in clustered mode

### DIFF
--- a/lxd/resource_lxd_instance_test.go
+++ b/lxd/resource_lxd_instance_test.go
@@ -507,8 +507,6 @@ func TestAccInstance_isStopped(t *testing.T) {
 }
 
 func TestAccInstance_target(t *testing.T) {
-	t.Skip("Test environment does not support clustering yet")
-
 	var instance api.Instance
 	instanceName := strings.ToLower(petname.Generate(2, "-"))
 

--- a/lxd/resource_lxd_network_test.go
+++ b/lxd/resource_lxd_network_test.go
@@ -129,12 +129,10 @@ func TestAccNetwork_typeMacvlan(t *testing.T) {
 }
 
 func TestAccNetwork_target(t *testing.T) {
-	t.Skip("Test environment does not support clustering yet")
-
 	var network api.Network
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckClustering(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/lxd/resource_lxd_storage_pool_test.go
+++ b/lxd/resource_lxd_storage_pool_test.go
@@ -33,8 +33,6 @@ func TestAccStoragePool_basic(t *testing.T) {
 }
 
 func TestAccStoragePool_target(t *testing.T) {
-	t.Skip("Test environment does not support clustering yet")
-
 	var pool api.StoragePool
 	poolName := strings.ToLower(petname.Generate(2, "-"))
 
@@ -44,7 +42,7 @@ func TestAccStoragePool_target(t *testing.T) {
 	source := "/mnt"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckClustering(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/lxd/resource_lxd_volume_test.go
+++ b/lxd/resource_lxd_volume_test.go
@@ -56,13 +56,11 @@ func TestAccVolume_containerAttach(t *testing.T) {
 }
 
 func TestAccVolume_target(t *testing.T) {
-	t.Skip("Test environment does not support clustering yet")
-
 	var volume api.StorageVolume
 	volumeName := strings.ToLower(petname.Generate(2, "-"))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckClustering(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
Use existing test prechecks for detecting whether LXD is in clustered mode.