### PR TITLE
docs/snapshot: stateful defaults to false

### DIFF
--- a/docs/resources/snapshot.md
+++ b/docs/resources/snapshot.md
@@ -22,7 +22,7 @@ resource "lxd_snapshot" "snap1" {
 
 * `stateful` - *Optional* - Set to `true` to create a stateful snapshot,
 	`false` for stateless. Stateful snapshots include runtime state. Defaults to
-	`true`.
+	`false`.
 
 * `project` - *Optional* - Name of the project where the snapshot will be stored.
 


### PR DESCRIPTION
This default of false is good because live container snapshots are not working in a meaningful way as of this writing (2023).