### PR TITLE
docs: Remove resources section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,6 @@ Alternatively, the LXD Terraform provider can generate them on demand if
 
 Minimum required LXD version is **`3.0`**.
 
-## Resources
-
-A list of supported resources can be found [here](resources).
-
 ## Basic Example
 
 This is all that is needed if the LXD remotes have been defined out of band via


### PR DESCRIPTION
Remove `Resources` section in `index.md` because link within the section does not work.

Alternatively, we can link each existing resource in this section, but they are displayed on the left side in the Terraform docs.