### PR TITLE
Skip determining unix socket if a remote config address is set

### DIFF
--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -537,9 +537,12 @@ func (p *lxdProvider) GetServer(remoteName string) (lxd.Server, error) {
 		}
 	}
 
-	// If scheme is set to unix, but address (socket path) is not provided
-	// then determine which LXD directory contains a writable unix socket.
-	if (remote.scheme == "" || remote.scheme == "unix") && remote.address == "" {
+	remoteConfig := p.getRemoteConfig(remoteName)
+
+	// If remote address is not provided or is only set to the prefix for
+	// Unix sockets (`unix://`) then determine which LXD directory
+	// contains a writable unix socket.
+	if remoteConfig.Addr == "" || remoteConfig.Addr == "unix://" {
 		lxdDir, err := determineLxdDir()
 		if err != nil {
 			return nil, err
@@ -550,7 +553,7 @@ func (p *lxdProvider) GetServer(remoteName string) (lxd.Server, error) {
 
 	var err error
 
-	switch p.getRemoteConfig(remoteName).Protocol {
+	switch remoteConfig.Protocol {
 	case "simplestreams":
 		client, err = p.getLXDImageClient(remoteName)
 	default:


### PR DESCRIPTION
This PR prevents unix socket to be determined if remote config address is set.

When this PR is merged, users will be able to create an arbitrary *default* remote and use it with `lxd-user` socket.
For example:
```hcl
provider "lxd" {
  lxd_remote {
    name     = "lxd-users"
    scheme   = "unix"
    address  = "/var/snap/lxd/common/lxd-user/unix.socket"
    default  = true
  }
}

resource "lxd_instance" "instance" {
  remote  = "lxd-users"
  project = "user-1001"

  name      = "tf-c1"
  image     = "images:alpine/3.16"
  ephemeral = false
}
```

^ Above currently does not work, because provider tries to determine the unix socket for LXD defined remotes (such as `images` remote).