### PR TITLE
Fix ignored error in instance/container exists function

### DIFF
--- a/lxd/resource_lxd_container.go
+++ b/lxd/resource_lxd_container.go
@@ -781,7 +781,7 @@ func resourceLxdContainerExists(d *schema.ResourceData, meta interface{}) (exist
 		exists = true
 	}
 
-	return exists, nil
+	return
 }
 
 func resourceLxdContainerImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/lxd/resource_lxd_instance.go
+++ b/lxd/resource_lxd_instance.go
@@ -781,7 +781,7 @@ func resourceLxdInstanceExists(d *schema.ResourceData, meta interface{}) (exists
 		exists = true
 	}
 
-	return exists, nil
+	return
 }
 
 func resourceLxdInstanceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {


### PR DESCRIPTION
Error was ignored in instance/container exists function.

While this fixes the issue, we should probably get rid of named returned values wherever possible to prevent such issues in the future. I think something like this is even more readable:
```go
_, _, err := server.GetInstanceState(name)
if err != nil {
         if isNotFoundError(err) {
                 return false, nil
         }
         
         return false, err
}

return true, nil
```

Any thoughts?