### PR TITLE
test: Drop VM test for old lxd_container resource

### DIFF
--- a/lxd/resource_lxd_container_test.go
+++ b/lxd/resource_lxd_container_test.go
@@ -68,25 +68,6 @@ func TestAccContainer_typeContainer(t *testing.T) {
 	})
 }
 
-func TestAccContainer_typeVirtualMachine(t *testing.T) {
-	var container api.Container
-	containerName := petname.Generate(2, "-")
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheckVirtualization(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainer_virtualmachine(containerName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccContainerRunning(t, "lxd_container.container1", &container),
-					resource.TestCheckResourceAttr("lxd_container.container1", "type", "virtual-machine"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccContainer_remoteImage(t *testing.T) {
 	var container api.Container
 	containerName := petname.Generate(2, "-")


### PR DESCRIPTION
~This is a bit of a workaround, but seems that client's `GetContainer()` is incapable of properly returning VM instances.~

~We can either drop the VM test for old container resource, or rely on `GetInstance()` to verify the container is running instead.~


```
$ lxc launch ubuntu:22.04 v1 --vm
$ lxc launch ubuntu:22.04 c1

$ lxc query -X GET /1.0/containers
[
        "/1.0/containers/c1"
]

$ lxc query -X GET /1.0/instances
[
        "/1.0/instances/c1",
        "/1.0/instances/v1"
]
```

EDIT:

This PR just removes VM test for `lxd_container` resource. Resource `lxd_container` will be dropped soon and VMs are also tested for `lxd_instance` resource.