### PR TITLE
Test for required API extensions in network LB and zones tests

### DIFF
--- a/lxd/resource_lxd_network_lb_test.go
+++ b/lxd/resource_lxd_network_lb_test.go
@@ -15,7 +15,7 @@ func TestAccNetworkLB_basic(t *testing.T) {
 	var lb api.NetworkLoadBalancer
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckAPIExtensions(t, []string{"network_load_balancer"}) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -39,7 +39,7 @@ func TestAccNetworkLB_withConfig(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckAPIExtensions(t, []string{"network_load_balancer"}) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -71,7 +71,7 @@ func TestAccNetworkLB_withBackend(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckAPIExtensions(t, []string{"network_load_balancer"}) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/lxd/resource_lxd_network_zone_test.go
+++ b/lxd/resource_lxd_network_zone_test.go
@@ -61,7 +61,7 @@ func TestAccNetworkZone_project(t *testing.T) {
 	projectName := petname.Name()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckAPIExtensions(t, []string{"projects_networks_zones"}) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
This is in preparation of supporting LXD `5.0/stable`.