### PR TITLE
Make LXD 4.0 the minimum officially supported version

### DIFF
--- a/lxd/errors.go
+++ b/lxd/errors.go
@@ -1,17 +1,11 @@
 package lxd
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/canonical/lxd/shared/api"
 )
 
 func isNotFoundError(err error) bool {
-	// For LXD versions below "4.0".
-	if err.Error() == "No such object" || err.Error() == "not found" {
-		return true
-	}
-
 	return api.StatusErrorCheck(err, http.StatusNotFound)
 }

--- a/lxd/errors.go
+++ b/lxd/errors.go
@@ -7,10 +7,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
-var errNetworksNotImplemented = errors.New("This LXD server does not support " +
-	"the creation of networks. You must be running LXD 2.3 or later for this " +
-	"feature.")
-
 func isNotFoundError(err error) bool {
 	// For LXD versions below "4.0".
 	if err.Error() == "No such object" || err.Error() == "not found" {

--- a/lxd/provider.go
+++ b/lxd/provider.go
@@ -20,7 +20,7 @@ import (
 var mutex sync.RWMutex
 
 // supportedLXDVersions defines LXD versions that are supported by the provider.
-const supportedLXDVersions = ">= 3.0.0"
+const supportedLXDVersions = ">= 4.0.0"
 
 // lxdProvider contains the Provider configuration and initialized remote clients.
 type lxdProvider struct {

--- a/lxd/provider_test.go
+++ b/lxd/provider_test.go
@@ -203,14 +203,6 @@ func testAccPreCheckAPIExtensions(t *testing.T, extensions []string) {
 
 // testAccPreCheckVirtualization skips the test if the LXD server does not support virtualization.
 func testAccPreCheckVirtualization(t *testing.T) {
-	client := getTestLXDInstanceClient(t)
-
-	// Ensure that LXD server has virtual-machines extension.
-	vmExt := "virtual-machines"
-	if !client.HasExtension(vmExt) {
-		t.Skipf("Test %q skipped. Server does not support %q extension.", t.Name(), vmExt)
-	}
-
 	server, _, err := getTestLXDInstanceClient(t).GetServer()
 	if err != nil {
 		t.Fatalf("Failed to retrieve the server: %v", err)

--- a/lxd/resource_lxd_network.go
+++ b/lxd/resource_lxd_network.go
@@ -106,10 +106,6 @@ func resourceLxdNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 	mutex.Unlock()
 
 	if err != nil {
-		if err.Error() == "not implemented" {
-			err = errNetworksNotImplemented
-		}
-
 		return err
 	}
 


### PR DESCRIPTION
LXD 4.0 is the oldest currently supported branch by LXD upstream.