### PR TITLE
Add exec block to the instance resource

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -156,6 +156,9 @@ The `exec` block supports:
 * `record_output` - *Optional* - When set to true, `stdout` and `stderr` attributes will be
   populated (exported). Defaults to `false`.
 
+* `fail_on_error` - *Optional* - Boolean indicating whether resource provisioning should stop upon
+  encountering an error during command execution. Defaults to `false`.
+
 * `uid` - *Optional* - The user ID for running command. Defaults to `0` (root).
 
 * `gid` - *Optional* - The group ID for running command. Defaults to `0` (root).
@@ -242,8 +245,10 @@ resource "lxd_instance" "inst" {
 
 ### Capturing Command Output
 
-To capture and access a command's output, set `record_output` to true. The command's standard output
-and standard error will then be accessible through the exported attributes `stdout` and `stderr`, respectively.
+Exit status of the command will be always available after command execution via `exit_code` attribute.
+However, to capture and access a command's output, set `record_output` to true. The command's standard
+output and standard error will then be accessible through the exported attributes `stdout` and `stderr`,
+respectively.
 
 ```hcl
 resource "lxd_instance" "inst" {
@@ -258,8 +263,26 @@ resource "lxd_instance" "inst" {
 
 output "exec-output" {
   value = {
-    "out" = lxd_instance.inst.exec[0].stdout # "Linux\n"
-    "err" = lxd_instance.inst.exec[0].stderr # ""
+    "code" = lxd_instance.inst.exec[0].exit_code # 0
+    "out"  = lxd_instance.inst.exec[0].stdout    # "Linux\n"
+    "err"  = lxd_instance.inst.exec[0].stderr    # ""
+  }
+}
+```
+
+### Fail on Command Error
+
+By default, command failure is ignored. If you want to stop Terraform from provisioning the resources
+if command exits with a non 0 status, set `fail_on_error` attribute to true.
+
+```hcl
+resource "lxd_instance" "inst" {
+  name      = "c1"
+  image     = "images:alpine/3.18/amd64"
+
+  exec {
+    command       = ["invalid-cmd"]
+    fail_on_error = true
   }
 }
 ```

--- a/internal/acctest/fixtures/test-script.sh
+++ b/internal/acctest/fixtures/test-script.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+hostname

--- a/internal/acctest/fixtures/test-script.sh
+++ b/internal/acctest/fixtures/test-script.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-hostname
+hostname | tr -d '\n'

--- a/internal/common/lxd_exec.go
+++ b/internal/common/lxd_exec.go
@@ -1,0 +1,166 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	lxd "github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/utils"
+)
+
+type ExecModel struct {
+	Command      types.List   `tfsdk:"command"`
+	Triggers     types.List   `tfsdk:"triggers"`
+	Environment  types.Map    `tfsdk:"environment"`
+	WorkingDir   types.String `tfsdk:"working_dir"`
+	RecordOutput types.Bool   `tfsdk:"record_output"`
+	UserID       types.Int64  `tfsdk:"uid"`
+	GroupID      types.Int64  `tfsdk:"gid"`
+	Output       types.String `tfsdk:"stdout"`
+	Error        types.String `tfsdk:"stderr"`
+}
+
+func (e *ExecModel) Execute(ctx context.Context, server lxd.InstanceServer, instanceName string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	env := make(map[string]string, len(e.Environment.Elements()))
+	diags.Append(e.Environment.ElementsAs(ctx, &env, false)...)
+
+	command := make([]string, 0, len(e.Command.Elements()))
+	diags.Append(e.Command.ElementsAs(ctx, &command, false)...)
+
+	if diags.HasError() {
+		return diags
+	}
+
+	// If command is one liner, split it on spaces.
+	if len(command) == 1 {
+		command = strings.SplitN(command[0], " ", 3)
+	}
+
+	execReq := api.InstanceExecPost{
+		Command:      command,
+		Environment:  env,
+		WaitForWS:    true,
+		Interactive:  false,
+		RecordOutput: false,
+		Cwd:          e.WorkingDir.ValueString(),
+		User:         uint32(e.GroupID.ValueInt64()),
+		Group:        uint32(e.UserID.ValueInt64()),
+	}
+
+	// Create buffers to capture stdout and stderr.
+	var outBuf utils.Buffer
+	var errBuf utils.Buffer
+
+	if e.RecordOutput.ValueBool() {
+		outBuf = utils.NewBufferCloser()
+		errBuf = utils.NewBufferCloser()
+	} else {
+		outBuf = utils.NewDiscardCloser()
+		errBuf = utils.NewDiscardCloser()
+	}
+
+	execArgs := &lxd.InstanceExecArgs{
+		Stdout: outBuf,
+		Stderr: errBuf,
+	}
+
+	// Run command.
+	opExec, err := server.ExecInstance(instanceName, execReq, execArgs)
+	if err == nil {
+		err = opExec.WaitContext(ctx)
+	}
+
+	if err != nil {
+		diags.Append(diag.NewErrorDiagnostic(
+			fmt.Sprintf("Failed to execute command on instance %q", instanceName),
+			err.Error(),
+		))
+		return diags
+	}
+
+	// Store command output.
+	e.Output = types.StringValue(outBuf.String())
+	e.Error = types.StringValue(errBuf.String())
+
+	if e.RecordOutput.ValueBool() && err != nil {
+		// If output is recorded and error is not nil, set
+		// error as stderr, because errBuf will be empty.
+		e.Error = types.StringValue(err.Error())
+	}
+
+	return nil
+}
+
+// Equals compares two execs and determines whether they are equal.
+func (e1 ExecModel) Equal(e2 ExecModel) bool {
+	if !e1.Command.Equal(e2.Command) {
+		return false
+	}
+
+	if !e1.Triggers.Equal(e2.Triggers) {
+		return false
+	}
+
+	return true
+}
+
+// ExecSlicesEqual returns true if there is no new command to be
+// executed.
+func ExecSlicesEqual(old []ExecModel, new []ExecModel) bool {
+	// If new exec block were added, new commands need
+	// to be run.
+	if len(new) > len(old) {
+		return false
+	}
+
+	// If any exec block has been changed, new commands
+	// need to be run.
+	for i := range old {
+		if i >= len(new) {
+			break
+		}
+
+		if !old[i].Equal(new[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ToExecList converts list of exec blocks of type types.List
+// into list of exec structures.
+func ToExecList(ctx context.Context, execList types.List) ([]ExecModel, diag.Diagnostics) {
+	if execList.IsNull() {
+		return []ExecModel{}, nil
+	}
+
+	execs := make([]ExecModel, 0, len(execList.Elements()))
+	diags := execList.ElementsAs(ctx, &execs, false)
+	return execs, diags
+}
+
+// ToExecList converts list of exec blocks of type types.List
+// into list of exec structures.
+func ToExecListType(ctx context.Context, execs []ExecModel) (types.List, diag.Diagnostics) {
+	execType := map[string]attr.Type{
+		"command":       types.ListType{ElemType: types.StringType},
+		"triggers":      types.ListType{ElemType: types.StringType},
+		"environment":   types.MapType{ElemType: types.StringType},
+		"working_dir":   types.StringType,
+		"record_output": types.BoolType,
+		"uid":           types.Int64Type,
+		"gid":           types.Int64Type,
+		"stdout":        types.StringType,
+		"stderr":        types.StringType,
+	}
+
+	return types.ListValueFrom(ctx, types.ObjectType{AttrTypes: execType}, execs)
+}

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -331,6 +331,13 @@ func (r InstanceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 							Default:     booldefault.StaticBool(false),
 						},
 
+						"fail_on_error": schema.BoolAttribute{
+							Description: "Whether to fail on command error",
+							Optional:    true,
+							Computed:    true,
+							Default:     booldefault.StaticBool(false),
+						},
+
 						"uid": schema.Int64Attribute{
 							Description: "The user ID for running command",
 							Optional:    true,
@@ -350,6 +357,11 @@ func (r InstanceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						},
 
 						// Computed.
+
+						"exit_code": schema.Int64Attribute{
+							Description: "Exit code of the command",
+							Computed:    true,
+						},
 
 						"stdout": schema.StringAttribute{
 							Description: "Command standard output (if recorded)",
@@ -838,6 +850,7 @@ func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest
 		if i < len(oldExecs) {
 			// Copy computed fields in case the command has
 			// not changed.
+			newExecs[i].ExitCode = oldExecs[i].ExitCode
 			newExecs[i].Output = oldExecs[i].Output
 			newExecs[i].Error = oldExecs[i].Error
 

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -566,6 +566,7 @@ func TestAccInstance_execOutput(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "0"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", ""),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
 				),
@@ -576,6 +577,7 @@ func TestAccInstance_execOutput(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "0"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", "Linux\n"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
 				),
@@ -586,6 +588,7 @@ func TestAccInstance_execOutput(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "0"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", ""),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
 				),
@@ -651,6 +654,7 @@ func TestAccInstance_execWorkingDir(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "0"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", "ID=alpine"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
 				),
@@ -672,7 +676,75 @@ func TestAccInstance_execEnvironment(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "0"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", "It works.\n"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccInstance_execScript(t *testing.T) {
+	instanceName := petname.Generate(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_execScript(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "file.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "0"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", fmt.Sprintf("%s\n", instanceName)),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccInstance_execError(t *testing.T) {
+	instanceName := petname.Generate(2, "-")
+
+	resource.Test(t, resource.TestCase{
+
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Ensure command error is recorded and terraform apply is
+				// not disturbed if fail_on_error is unset (or set to false).
+				Config: testAccInstance_execError_1(instanceName, false /* fail on error */),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "127"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", ""),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", "Command not found"),
+				),
+				ExpectNonEmptyPlan: true, // timestamp() in triggers.
+			},
+			{
+				// Ensure terraform apply fails on command error
+				// if fail_on_error is set to true.
+				Config:      testAccInstance_execError_1(instanceName, true /* fail on error */),
+				ExpectError: regexp.MustCompile("Error: Failed to execute command"),
+			},
+			{
+				// Ensures exit_code is set even if output is not recorded.
+				Config: testAccInstance_execError_2(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", ""),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
 				),
 			},
@@ -893,8 +965,7 @@ resource "lxd_instance" "instance1" {
   image     = "%s"
   running   = false
   ephemeral = true
-}
-	`, name, acctest.TestImage)
+}`, name, acctest.TestImage)
 }
 
 func testAccInstance_container(name string) string {
@@ -1332,8 +1403,57 @@ resource "lxd_instance" "instance1" {
     command       = ["sh", "-c", "echo $ENV_TEST"]
     record_output = true
     environment = {
-	"ENV_TEST" = "It works."
+      "ENV_TEST" = "It works."
     }
+  }
+}
+	`, instanceName, acctest.TestImage)
+}
+
+func testAccInstance_execScript(instanceName string) string {
+	return fmt.Sprintf(`
+resource "lxd_instance" "instance1" {
+  name  = "%s"
+  image = "%s"
+
+  file {
+    source_path        = "../acctest/fixtures/test-script.sh"
+    target_path        = "/root/test-script.sh"
+    mode               = "0700"
+  }
+
+  exec {
+    command       = ["sh test-script.sh"]
+    record_output = true
+  }
+}
+	`, instanceName, acctest.TestImage)
+}
+
+func testAccInstance_execError_1(instanceName string, failOnError bool) string {
+	return fmt.Sprintf(`
+resource "lxd_instance" "instance1" {
+  name  = "%s"
+  image = "%s"
+
+  exec {
+    command       = ["invalid"]
+    triggers      = [timestamp()]
+    record_output = true
+    fail_on_error = "%v"
+  }
+}
+	`, instanceName, acctest.TestImage, failOnError)
+}
+
+func testAccInstance_execError_2(instanceName string, triggers ...string) string {
+	return fmt.Sprintf(`
+resource "lxd_instance" "instance1" {
+  name  = "%s"
+  image = "%s"
+
+  exec {
+    command = ["sh", "-c", "ls / | grep 'nothing'"]
   }
 }
 	`, instanceName, acctest.TestImage)

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -677,7 +677,7 @@ func TestAccInstance_execEnvironment(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "0"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", "It works.\n"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", "It works."),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
 				),
 			},
@@ -700,7 +700,7 @@ func TestAccInstance_execScript(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "file.#", "1"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.#", "1"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.exit_code", "0"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", fmt.Sprintf("%s\n", instanceName)),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stdout", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "exec.0.stderr", ""),
 				),
 			},
@@ -1385,7 +1385,10 @@ resource "lxd_instance" "instance1" {
   image = "%s"
 
   exec {
-    command       = ["sh", "-c", "cat os-release | grep '^ID' | tr -d '\n'"]
+    command = [
+      "/bin/sh", "-c",
+      "cat os-release | grep '^ID' | tr -d '\n'"
+    ]
     working_dir   = "/etc"
     record_output = true
   }
@@ -1400,8 +1403,9 @@ resource "lxd_instance" "instance1" {
   image = "%s"
 
   exec {
-    command       = ["sh", "-c", "echo $ENV_TEST"]
+    command       = ["/bin/sh", "-c", "echo -n $ENV_TEST"]
     record_output = true
+
     environment = {
       "ENV_TEST" = "It works."
     }
@@ -1417,13 +1421,13 @@ resource "lxd_instance" "instance1" {
   image = "%s"
 
   file {
-    source_path        = "../acctest/fixtures/test-script.sh"
-    target_path        = "/root/test-script.sh"
-    mode               = "0700"
+    source_path = "../acctest/fixtures/test-script.sh"
+    target_path = "/root/test-script.sh"
+    mode        = "0700"
   }
 
   exec {
-    command       = ["sh test-script.sh"]
+    command       = ["/bin/sh", "test-script.sh"]
     record_output = true
   }
 }
@@ -1453,7 +1457,7 @@ resource "lxd_instance" "instance1" {
   image = "%s"
 
   exec {
-    command = ["sh", "-c", "ls / | grep 'nothing'"]
+    command = ["/bin/sh", "-c", "ls / | grep 'nothing'"]
   }
 }
 	`, instanceName, acctest.TestImage)

--- a/internal/utils/buffer.go
+++ b/internal/utils/buffer.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// Buffer interface satisfies io.ReadCloser, io.WriteCloser, and fmt.Stringer.
+type Buffer interface {
+	fmt.Stringer
+	io.Reader
+	io.Writer
+	io.Closer
+}
+
+type bufferCloser struct {
+	buf *bytes.Buffer
+	mux *sync.RWMutex
+}
+
+// BufferCloser returns a buffer that wraps bytes.Buffer and satisfies
+// io.Closer.
+func NewBufferCloser() Buffer {
+	return bufferCloser{
+		buf: &bytes.Buffer{},
+		mux: &sync.RWMutex{},
+	}
+}
+
+func (b bufferCloser) Write(p []byte) (int, error) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b bufferCloser) Read(p []byte) (int, error) {
+	b.mux.RLock()
+	defer b.mux.RUnlock()
+	return b.buf.Read(p)
+}
+
+func (b bufferCloser) Close() error {
+	return nil
+}
+
+func (b bufferCloser) String() string {
+	b.mux.RLock()
+	defer b.mux.RUnlock()
+	return b.buf.String()
+}
+
+type discardCloser struct{}
+
+// NewDiscardCloser returns a buffer that simply discards everything.
+func NewDiscardCloser() Buffer {
+	return discardCloser{}
+}
+
+func (b discardCloser) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (b discardCloser) Read(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (b discardCloser) Close() error {
+	return nil
+}
+
+func (b discardCloser) String() string {
+	return ""
+}


### PR DESCRIPTION
This PR adds `exec` block to the instance resource which allows running commands within the instance.

- [x] Requires #385 to be rebased.
- [x] Requires #387 to be able to properly manage `exec` state.

Fixes #54