### PR TITLE
Remove refresh_interval attribute from provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,10 +75,6 @@ The following arguments are supported:
 	also be set with the `LXD_ACCEPT_SERVER_CERTIFICATE` environment variable.
   Defaults to `false`
 
-* `refresh_interval` - *Optional* - How often to poll during state change.
-	Defaults to "10s", or 10 seconds. Valid values are a Go-style parsable time
-	duration (`10s`, `1m`, `5h`).
-
 The `remote` block supports:
 
 * `address` - *Optional* - The address of the LXD remote.

--- a/internal/acctest/provider_factory.go
+++ b/internal/acctest/provider_factory.go
@@ -2,7 +2,6 @@ package acctest
 
 import (
 	"sync"
-	"time"
 
 	lxd_config "github.com/canonical/lxd/lxc/config"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -29,9 +28,8 @@ func testProvider() *provider_config.LxdProviderConfig {
 
 	if testProviderConfig == nil {
 		config := lxd_config.DefaultConfig()
-		refreshInterval := time.Duration(2 * time.Second)
 		acceptClientCert := true
-		testProviderConfig = provider_config.NewLxdProvider(config, refreshInterval, acceptClientCert)
+		testProviderConfig = provider_config.NewLxdProvider(config, acceptClientCert)
 	}
 
 	return testProviderConfig
@@ -42,5 +40,5 @@ func testProvider() *provider_config.LxdProviderConfig {
 // CLI command executed to create a provider server to which the CLI can
 // reattach.
 var ProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
-	"lxd": providerserver.NewProtocol6WithError(provider.NewLxdProvider("test", "2s")()),
+	"lxd": providerserver.NewProtocol6WithError(provider.NewLxdProvider("test")()),
 }

--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	lxd_config "github.com/canonical/lxd/lxc/config"
@@ -39,10 +38,6 @@ type LxdProviderConfig struct {
 	// should be accepted.
 	acceptServerCertificate bool
 
-	// refreshInterval is a custom interval for communicating with remote
-	// LXD servers.
-	refreshInterval time.Duration
-
 	// LXDConfig is the converted form of terraformLXDConfig
 	// in LXD's native data structure. This is lazy-loaded / created
 	// only when a connection to an LXD remote/server happens.
@@ -69,10 +64,9 @@ type LxdProviderConfig struct {
 // NewLxdProvider returns initialized LXD provider structure. This struct is
 // used to store information about this Terraform provider's configuration for
 // reference throughout the lifecycle.
-func NewLxdProvider(lxdConfig *lxd_config.Config, refreshInterval time.Duration, acceptServerCert bool) *LxdProviderConfig {
+func NewLxdProvider(lxdConfig *lxd_config.Config, acceptServerCert bool) *LxdProviderConfig {
 	return &LxdProviderConfig{
 		acceptServerCertificate: acceptServerCert,
-		refreshInterval:         refreshInterval,
 		lxdConfig:               lxdConfig,
 		remotes:                 make(map[string]LxdProviderRemoteConfig),
 		servers:                 make(map[string]lxd.Server),
@@ -495,10 +489,4 @@ func (p *LxdProviderConfig) getLxdConfigImageServer(remoteName string) (lxd.Imag
 	p.mux.RLock()
 	defer p.mux.RUnlock()
 	return p.lxdConfig.GetImageServer(remoteName)
-}
-
-// RefreshInterval returns a time interval on which provider should
-// retry to communicate with the LXD server.
-func (p *LxdProviderConfig) RefreshInterval() time.Duration {
-	return p.refreshInterval
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 // version indicates provider's version. The appropriate value
-// for the compile binary will be set by the goreleaser.
+// for the compiled binary will be set by the goreleaser.
 // See: https://goreleaser.com/cookbooks/using-main.version/
 var version = "dev"
 
@@ -34,7 +34,7 @@ func main() {
 		ProtocolVersion: 6,
 	}
 
-	err := providerserver.Serve(context.Background(), provider.NewLxdProvider(version, "10s"), opts)
+	err := providerserver.Serve(context.Background(), provider.NewLxdProvider(version), opts)
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
Currently documentation for provider's `refresh_interval` states:
> How often to poll during state change.

However, this is a bit misleading. Refresh interval is used only within instance resource as `Delay` in `retry.StateChangeConf`.

[retry.StateChangeConf](https://github.com/hashicorp/terraform-plugin-sdk/blob/b48765e952eee6ff8d420ca7793325bffaea34de/helper/retry/state.go#L27C1-L39C2) has the following fields:
- `Timeout` - Maximum time to wait for the desired state.
- `MinTimeout` - Minimum time between checks, which keeps increasing by *times 2* with each unsuccessful wait up to 10 seconds. 
  - For example, if `MinTimeout = 2`, the polling would happen on 2, 4, 8, 10, 10, 10, ... seconds.
- `Delay` - Initial delay before the first check/refresh.
- `PollInterval` - Fixed polling interval (*currently not used*).

An instance with `running=true` and `wait_for_network=true` with delay of 10 seconds takes at least 20 seconds to be recognized as started.

This PR removes refresh_interval attribute and sets initial delay and minimum timeout to 2 seconds. Alternatively, we could use refresh_interval for *fixed* polling interval, if anyone sees use in that?
