### PR TITLE
Add instance timeouts

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -190,6 +190,30 @@ The following attributes are exported:
 
 * `status` - The status of the instance.
 
+## Timeouts
+
+Configuration options:
+* `read` - Default `5m`
+* `create` - Default `5m`
+* `update` - Default `5m`
+* `delete` - Default `5m`
+
+If you need to set custom timeout durations for any of these operations,
+you can specify them in your Terraform configuration as shown in the following example:
+```hcl
+resource "lxd_instance" "inst" {
+  name  = "c1"
+  image = "ubuntu-daily:22.04"
+
+  timeouts = {
+    read   = "10m"
+    create = "10m"
+    update = "10m"
+    delete = "10m"
+  }
+}
+```
+
 ## Instance Network Access
 
 If your instance has multiple network interfaces, you can specify which one

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.5.0
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.20.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/hashicorp/terraform-json v0.19.0 h1:e9DBKC5sxDfiJT7Zoi+yRIwqLVtFur/fw
 github.com/hashicorp/terraform-json v0.19.0/go.mod h1:qdeBs11ovMzo5puhrRibdD6d2Dq6TyE/28JiU4tIQxk=
 github.com/hashicorp/terraform-plugin-framework v1.5.0 h1:8kcvqJs/x6QyOFSdeAyEgsenVOUeC/IyKpi2ul4fjTg=
 github.com/hashicorp/terraform-plugin-framework v1.5.0/go.mod h1:6waavirukIlFpVpthbGd2PUNYaFedB0RwW3MDzJ/rtc=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 h1:gm5b1kHgFFhaKFhm4h2TgvMUlNzFAtUqlcOWnWPm+9E=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1/go.mod h1:MsjL1sQ9L7wGwzJ5RjcI6FzEMdyoBnw+XK8ZnOvQOLY=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.20.0 h1:oqvoUlL+2EUbKNsJbIt3zqqZ7wi6lzn4ufkn/UA51xQ=

--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	lxd_config "github.com/canonical/lxd/lxc/config"
@@ -489,4 +490,10 @@ func (p *LxdProviderConfig) getLxdConfigImageServer(remoteName string) (lxd.Imag
 	p.mux.RLock()
 	defer p.mux.RUnlock()
 	return p.lxdConfig.GetImageServer(remoteName)
+}
+
+// DefaultTimeout returns the default time period after which a resource
+// action (read/create/update/delete) is expected to time out.
+func (p *LxdProviderConfig) DefaultTimeout() time.Duration {
+	return 5 * time.Minute
 }


### PR DESCRIPTION
This PR adds default timeout of 5 minutes for all instance CRUD functions.

If necessary, custom timeouts can be set:
```hcl
resource "lxd_instance" "inst" {
  name  = "test"
  image = "ubuntu:22.04"

  timeouts = {
    read   = "1m"
    create = "2m"
    update = "3m"
    delete = "4m"
  }
}
```

Exec will also respect the resource timeout and stop once the context deadline is exceeded.

Fixes #422