### PR TITLE
Generate unique names for test resources

### DIFF
--- a/internal/acctest/testutils.go
+++ b/internal/acctest/testutils.go
@@ -1,0 +1,28 @@
+package acctest
+
+import (
+	"math/rand"
+
+	petname "github.com/dustinkirkland/golang-petname"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// generateString generates a random string of the given length.
+func generateString(length int) string {
+	s := make([]byte, length)
+	for i := range s {
+		s[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(s)
+}
+
+// GenerateName generates a petname with a random string suffix.
+// If requested number of words is 1 or less, just petname is returned.
+func GenerateName(words int, separator string) string {
+	if words <= 1 {
+		return petname.Name()
+	}
+
+	return petname.Generate(words-1, separator) + separator + generateString(6)
+}

--- a/internal/image/resource_cached_image_test.go
+++ b/internal/image/resource_cached_image_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
@@ -49,8 +48,8 @@ func TestAccCachedImage_basicVM(t *testing.T) {
 }
 
 func TestAccCachedImage_alias(t *testing.T) {
-	alias1 := petname.Generate(2, "-")
-	alias2 := petname.Generate(2, "-")
+	alias1 := acctest.GenerateName(2, "-")
+	alias2 := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -73,8 +72,8 @@ func TestAccCachedImage_alias(t *testing.T) {
 }
 
 func TestAccCachedImage_copiedAliases(t *testing.T) {
-	alias1 := petname.Generate(2, "-")
-	alias2 := petname.Generate(2, "-")
+	alias1 := acctest.GenerateName(2, "-")
+	alias2 := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -118,7 +117,7 @@ func TestAccCachedImage_aliasCollision(t *testing.T) {
 }
 
 func TestAccCachedImage_aliasExists(t *testing.T) {
-	alias := petname.Generate(2, "-")
+	alias := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -150,8 +149,8 @@ func TestAccCachedImage_aliasExists(t *testing.T) {
 }
 
 func TestAccCachedImage_addRemoveAlias(t *testing.T) {
-	alias1 := petname.Generate(2, "-")
-	alias2 := petname.Generate(2, "-")
+	alias1 := acctest.GenerateName(2, "-")
+	alias2 := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -196,7 +195,7 @@ func TestAccCachedImage_addRemoveAlias(t *testing.T) {
 }
 
 func TestAccCachedImage_project(t *testing.T) {
-	projectName := petname.Name()
+	projectName := acctest.GenerateName(2, "")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/image/resource_publish_image_test.go
+++ b/internal/image/resource_publish_image_test.go
@@ -5,13 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccPublishImage_basic(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -33,7 +32,7 @@ func TestAccPublishImage_basic(t *testing.T) {
 }
 
 func TestAccPublishImage_aliases(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 	aliases := []string{"alias1", "alias2"}
 
 	resource.Test(t, resource.TestCase{
@@ -57,7 +56,7 @@ func TestAccPublishImage_aliases(t *testing.T) {
 }
 
 func TestAccPublishImage_properties(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 	properties := map[string]string{"os": "Alpine", "version": "4"}
 
 	resource.Test(t, resource.TestCase{
@@ -82,8 +81,8 @@ func TestAccPublishImage_properties(t *testing.T) {
 }
 
 func TestAccPublishImage_project(t *testing.T) {
-	projectName := petname.Name()
-	instanceName := petname.Generate(2, "-")
+	projectName := acctest.GenerateName(2, "")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/instance/resource_instance_file_test.go
+++ b/internal/instance/resource_instance_file_test.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccInstanceFile_basic(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -58,8 +57,8 @@ func TestAccInstanceFile_basic(t *testing.T) {
 }
 
 func TestAccInstanceFile_project(t *testing.T) {
-	projectName := petname.Name()
-	instanceName := petname.Generate(2, "-")
+	projectName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/instance/resource_instance_snapshot_test.go
+++ b/internal/instance/resource_instance_snapshot_test.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccInstanceSnapshot_stateless(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
-	snapshotName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
+	snapshotName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -34,8 +33,8 @@ func TestAccInstanceSnapshot_stateless(t *testing.T) {
 
 // TODO: Test requires CRIU
 // func TestAccInstanceSnapshot_stateful(t *testing.T) {
-// 	instanceName := petname.Generate(2, "-")
-// 	snapshotName := petname.Generate(2, "-")
+// 	instanceName := acctest.GenerateName(2, "-")
+// 	snapshotName := acctest.GenerateName(2, "-")
 
 // 	resource.Test(t, resource.TestCase{
 // 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -56,9 +55,9 @@ func TestAccInstanceSnapshot_stateless(t *testing.T) {
 // }
 
 func TestAccInstanceSnapshot_multiple(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
-	snapshotName1 := petname.Generate(2, "-")
-	snapshotName2 := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
+	snapshotName1 := acctest.GenerateName(2, "-")
+	snapshotName2 := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -92,9 +91,9 @@ func TestAccInstanceSnapshot_multiple(t *testing.T) {
 }
 
 func TestAccInstanceSnapshot_project(t *testing.T) {
-	projectName := petname.Name()
-	instanceName := petname.Generate(2, "-")
-	snapshotName := petname.Generate(2, "-")
+	projectName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
+	snapshotName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -5,13 +5,12 @@ import (
 	"regexp"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccInstance_basic(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -33,7 +32,7 @@ func TestAccInstance_basic(t *testing.T) {
 }
 
 func TestAccInstance_ephemeral(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -54,7 +53,7 @@ func TestAccInstance_ephemeral(t *testing.T) {
 }
 
 func TestAccInstance_ephemeralStopped(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -69,7 +68,7 @@ func TestAccInstance_ephemeralStopped(t *testing.T) {
 }
 
 func TestAccInstance_container(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -89,7 +88,7 @@ func TestAccInstance_container(t *testing.T) {
 }
 
 func TestAccInstance_virtualMachine(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -111,7 +110,7 @@ func TestAccInstance_virtualMachine(t *testing.T) {
 }
 
 func TestAccInstance_virtualMachineNoDevLxd(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -134,7 +133,7 @@ func TestAccInstance_virtualMachineNoDevLxd(t *testing.T) {
 }
 
 func TestAccInstance_restartContainer(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 	instanceType := "container"
 
 	resource.Test(t, resource.TestCase{
@@ -175,7 +174,7 @@ func TestAccInstance_restartContainer(t *testing.T) {
 }
 
 func TestAccInstance_restartVirtualMachine(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 	instanceType := "virtual-machine"
 
 	resource.Test(t, resource.TestCase{
@@ -218,7 +217,7 @@ func TestAccInstance_restartVirtualMachine(t *testing.T) {
 }
 
 func TestAccInstance_remoteImage(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -237,7 +236,7 @@ func TestAccInstance_remoteImage(t *testing.T) {
 }
 
 func TestAccInstance_config(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -256,7 +255,7 @@ func TestAccInstance_config(t *testing.T) {
 }
 
 func TestAccInstance_updateConfig(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -296,8 +295,8 @@ func TestAccInstance_updateConfig(t *testing.T) {
 }
 
 func TestAccInstance_addProfile(t *testing.T) {
-	profileName := petname.Generate(2, "-")
-	instanceName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -328,8 +327,8 @@ func TestAccInstance_addProfile(t *testing.T) {
 }
 
 func TestAccInstance_removeProfile(t *testing.T) {
-	profileName := petname.Generate(2, "-")
-	instanceName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -361,7 +360,7 @@ func TestAccInstance_removeProfile(t *testing.T) {
 }
 
 func TestAccInstance_noProfile(t *testing.T) {
-	name := petname.Generate(2, "-")
+	name := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -386,7 +385,7 @@ func TestAccInstance_noProfile(t *testing.T) {
 }
 
 func TestAccInstance_device(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -421,7 +420,7 @@ func TestAccInstance_device(t *testing.T) {
 }
 
 func TestAccInstance_addDevice(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -452,7 +451,7 @@ func TestAccInstance_addDevice(t *testing.T) {
 }
 
 func TestAccInstance_removeDevice(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -483,7 +482,7 @@ func TestAccInstance_removeDevice(t *testing.T) {
 }
 
 func TestAccInstance_fileUploadContent(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -530,7 +529,7 @@ func TestAccInstance_fileUploadContent(t *testing.T) {
 }
 
 func TestAccInstance_fileUploadSource(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -553,7 +552,7 @@ func TestAccInstance_fileUploadSource(t *testing.T) {
 }
 
 func TestAccInstance_execOutput(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -599,7 +598,7 @@ func TestAccInstance_execOutput(t *testing.T) {
 }
 
 func TestAccInstance_execOutputDate(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -633,7 +632,7 @@ func TestAccInstance_execOutputDate(t *testing.T) {
 }
 
 func TestAccInstance_execTriggerOnce(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -671,7 +670,7 @@ func TestAccInstance_execTriggerOnce(t *testing.T) {
 }
 
 func TestAccInstance_execTriggerOnStart(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -748,7 +747,7 @@ func TestAccInstance_execTriggerOnStart(t *testing.T) {
 }
 
 func TestAccInstance_execTriggerOnChange(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -781,7 +780,7 @@ func TestAccInstance_execTriggerOnChange(t *testing.T) {
 }
 
 func TestAccInstance_execEnabled(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -832,7 +831,7 @@ func TestAccInstance_execEnabled(t *testing.T) {
 }
 
 func TestAccInstance_execWorkingDir(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -854,7 +853,7 @@ func TestAccInstance_execWorkingDir(t *testing.T) {
 }
 
 func TestAccInstance_execEnvironment(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -876,7 +875,7 @@ func TestAccInstance_execEnvironment(t *testing.T) {
 }
 
 func TestAccInstance_execScript(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -899,7 +898,7 @@ func TestAccInstance_execScript(t *testing.T) {
 }
 
 func TestAccInstance_execOrder(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -927,7 +926,7 @@ func TestAccInstance_execOrder(t *testing.T) {
 }
 
 func TestAccInstance_execError(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 
@@ -970,7 +969,7 @@ func TestAccInstance_execError(t *testing.T) {
 }
 
 func TestAccInstance_configLimits(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -1000,17 +999,17 @@ func TestAccInstance_configLimits(t *testing.T) {
 }
 
 func TestAccInstance_accessInterface(t *testing.T) {
-	networkName1 := petname.Generate(1, "-")
-	instanceName := petname.Generate(2, "-")
+	networkName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstance_accessInterface(networkName1, instanceName),
+				Config: testAccInstance_accessInterface(networkName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("lxd_network.network1", "name", networkName1),
+					resource.TestCheckResourceAttr("lxd_network.network1", "name", networkName),
 					resource.TestCheckResourceAttr("lxd_network.network1", "config.ipv4.address", "10.150.19.1/24"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
@@ -1020,7 +1019,7 @@ func TestAccInstance_accessInterface(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.name", "eth0"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.type", "nic"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.nictype", "bridged"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.parent", networkName1),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.parent", networkName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.hwaddr", "00:16:3e:39:7f:36"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.ipv4.address", "10.150.19.200"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "mac_address", "00:16:3e:39:7f:36"),
@@ -1033,7 +1032,7 @@ func TestAccInstance_accessInterface(t *testing.T) {
 }
 
 func TestAccInstance_target(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -1060,8 +1059,8 @@ func TestAccInstance_target(t *testing.T) {
 }
 
 func TestAccInstance_createProject(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
-	projectName := petname.Name()
+	instanceName := acctest.GenerateName(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -1081,8 +1080,8 @@ func TestAccInstance_createProject(t *testing.T) {
 }
 
 func TestAccInstance_removeProject(t *testing.T) {
-	projectName := petname.Generate(2, "-")
-	instanceName := petname.Generate(2, "-")
+	projectName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -1111,7 +1110,7 @@ func TestAccInstance_removeProject(t *testing.T) {
 }
 
 func TestAccInstance_timeout(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -1126,7 +1125,7 @@ func TestAccInstance_timeout(t *testing.T) {
 }
 
 func TestAccInstance_importBasic(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 	resourceName := "lxd_instance.instance1"
 
 	resource.Test(t, resource.TestCase{
@@ -1148,8 +1147,8 @@ func TestAccInstance_importBasic(t *testing.T) {
 }
 
 func TestAccInstance_importProject(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
-	projectName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 	resourceName := "lxd_instance.instance1"
 
 	resource.Test(t, resource.TestCase{

--- a/internal/network/resource_network_lb_test.go
+++ b/internal/network/resource_network_lb_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/canonical/lxd/shared/api"
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
@@ -68,7 +67,7 @@ func TestAccNetworkLB_withConfig(t *testing.T) {
 }
 
 func TestAccNetworkLB_withBackend(t *testing.T) {
-	instanceName := petname.Generate(2, "")
+	instanceName := acctest.GenerateName(2, "")
 
 	backend := api.NetworkLoadBalancerBackend{
 		Name:          "backend",

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
@@ -49,8 +48,8 @@ func TestAccNetwork_description(t *testing.T) {
 }
 
 func TestAccNetwork_attach(t *testing.T) {
-	profileName := petname.Generate(2, "-")
-	instanceName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -80,7 +79,7 @@ func TestAccNetwork_attach(t *testing.T) {
 }
 
 func TestAccNetwork_updateConfig(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -134,7 +133,7 @@ func TestAccNetwork_typeMacvlan(t *testing.T) {
 }
 
 func TestAccNetwork_target(t *testing.T) {
-	networkName := petname.Name()
+	networkName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -162,7 +161,7 @@ func TestAccNetwork_target(t *testing.T) {
 }
 
 func TestAccNetwork_project(t *testing.T) {
-	projectName := petname.Name()
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -224,7 +223,7 @@ func TestAccNetwork_importDesc(t *testing.T) {
 
 func TestAccNetwork_importProject(t *testing.T) {
 	resourceName := "lxd_network.eth1"
-	projectName := petname.Name()
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/network/resource_network_zone_record_test.go
+++ b/internal/network/resource_network_zone_record_test.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccNetworkZoneRecord_basic(t *testing.T) {
-	recordName := petname.Generate(2, "-")
-	zoneName := petname.Generate(3, ".")
+	recordName := acctest.GenerateName(2, "-")
+	zoneName := acctest.GenerateName(3, ".")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -32,8 +31,8 @@ func TestAccNetworkZoneRecord_basic(t *testing.T) {
 }
 
 func TestAccNetworkZoneRecord_entries(t *testing.T) {
-	recordName := petname.Generate(2, "-")
-	zoneName := petname.Generate(3, ".")
+	recordName := acctest.GenerateName(2, "-")
+	zoneName := acctest.GenerateName(3, ".")
 
 	entry1 := map[string]string{
 		"type":  "CNAME",
@@ -75,8 +74,8 @@ func TestAccNetworkZoneRecord_entries(t *testing.T) {
 
 func TestAccNetworkZoneRecord_importBasic(t *testing.T) {
 	resourceName := "lxd_network_zone_record.record"
-	recordName := petname.Generate(2, "-")
-	zoneName := petname.Generate(3, ".")
+	recordName := acctest.GenerateName(2, "-")
+	zoneName := acctest.GenerateName(3, ".")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/network/resource_network_zone_test.go
+++ b/internal/network/resource_network_zone_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
@@ -58,7 +57,7 @@ func TestAccNetworkZone_description(t *testing.T) {
 }
 
 func TestAccNetworkZone_project(t *testing.T) {
-	projectName := petname.Name()
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -102,7 +101,7 @@ func TestAccNetworkZone_importBasic(t *testing.T) {
 
 func TestAccNetworkZone_importProject(t *testing.T) {
 	resourceName := "lxd_network_zone.zone"
-	projectName := petname.Name()
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/internal/profile/resource_profile_test.go
+++ b/internal/profile/resource_profile_test.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccProfile_basic(t *testing.T) {
-	profileName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -28,7 +27,7 @@ func TestAccProfile_basic(t *testing.T) {
 }
 
 func TestAccProfile_config(t *testing.T) {
-	profileName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -47,7 +46,7 @@ func TestAccProfile_config(t *testing.T) {
 }
 
 func TestAccProfile_device(t *testing.T) {
-	profileName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -80,7 +79,7 @@ func TestAccProfile_device(t *testing.T) {
 }
 
 func TestAccProfile_addDevice(t *testing.T) {
-	profileName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -131,7 +130,7 @@ func TestAccProfile_addDevice(t *testing.T) {
 }
 
 func TestAccProfile_removeDevice(t *testing.T) {
-	profileName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -160,8 +159,8 @@ func TestAccProfile_removeDevice(t *testing.T) {
 }
 
 func TestAccProfile_instanceConfig(t *testing.T) {
-	profileName := petname.Generate(2, "-")
-	instanceName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -185,8 +184,8 @@ func TestAccProfile_instanceConfig(t *testing.T) {
 }
 
 func TestAccProfile_instanceDevice(t *testing.T) {
-	profileName := petname.Generate(2, "-")
-	instanceName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -213,8 +212,8 @@ func TestAccProfile_instanceDevice(t *testing.T) {
 }
 
 func TestAccProfile_project(t *testing.T) {
-	profileName := petname.Generate(2, "-")
-	projectName := petname.Name()
+	profileName := acctest.GenerateName(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -235,7 +234,7 @@ func TestAccProfile_project(t *testing.T) {
 }
 
 func TestAccProfile_importBasic(t *testing.T) {
-	profileName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
 	resourceName := "lxd_profile.profile1"
 
 	resource.Test(t, resource.TestCase{
@@ -257,7 +256,7 @@ func TestAccProfile_importBasic(t *testing.T) {
 }
 
 func TestAccProfile_importConfig(t *testing.T) {
-	profileName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
 	resourceName := "lxd_profile.profile1"
 
 	resource.Test(t, resource.TestCase{
@@ -279,7 +278,7 @@ func TestAccProfile_importConfig(t *testing.T) {
 }
 
 func TestAccProfile_importDevice(t *testing.T) {
-	profileName := petname.Generate(2, "-")
+	profileName := acctest.GenerateName(2, "-")
 	resourceName := "lxd_profile.profile1"
 
 	resource.Test(t, resource.TestCase{

--- a/internal/project/resource_project_test.go
+++ b/internal/project/resource_project_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
@@ -16,7 +15,7 @@ import (
 // - Verify that a subsequent terraform plan does not produce a diff/change.
 
 func TestAccProject_basic(t *testing.T) {
-	projectName := petname.Generate(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -39,7 +38,7 @@ func TestAccProject_basic(t *testing.T) {
 }
 
 func TestAccProject_config(t *testing.T) {
-	projectName := petname.Generate(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -61,7 +60,7 @@ func TestAccProject_config(t *testing.T) {
 }
 
 func TestAccProject_updateConfig(t *testing.T) {
-	projectName := petname.Generate(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/storage/resource_storage_pool_test.go
+++ b/internal/storage/resource_storage_pool_test.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccStoragePool_dir(t *testing.T) {
-	poolName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 	driverName := "dir"
 
 	resource.Test(t, resource.TestCase{
@@ -41,7 +40,7 @@ func TestAccStoragePool_dir(t *testing.T) {
 }
 
 func TestAccStoragePool_zfs(t *testing.T) {
-	poolName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 	driverName := "zfs"
 
 	resource.Test(t, resource.TestCase{
@@ -74,7 +73,7 @@ func TestAccStoragePool_zfs(t *testing.T) {
 }
 
 func TestAccStoragePool_lvm(t *testing.T) {
-	poolName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 	driverName := "lvm"
 
 	resource.Test(t, resource.TestCase{
@@ -108,7 +107,7 @@ func TestAccStoragePool_lvm(t *testing.T) {
 }
 
 func TestAccStoragePool_btrfs(t *testing.T) {
-	poolName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 	driverName := "btrfs"
 
 	resource.Test(t, resource.TestCase{
@@ -140,7 +139,7 @@ func TestAccStoragePool_btrfs(t *testing.T) {
 }
 
 func TestAccStoragePool_config(t *testing.T) {
-	poolName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -178,8 +177,8 @@ func TestAccStoragePool_config(t *testing.T) {
 }
 
 func TestAccStoragePool_project(t *testing.T) {
-	poolName := petname.Generate(2, "-")
-	projectName := petname.Name()
+	poolName := acctest.GenerateName(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 	driverName := "dir"
 
 	resource.Test(t, resource.TestCase{
@@ -202,7 +201,7 @@ func TestAccStoragePool_project(t *testing.T) {
 }
 
 func TestAccStoragePool_target(t *testing.T) {
-	poolName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 	driverName := "dir"
 
 	resource.Test(t, resource.TestCase{
@@ -230,7 +229,7 @@ func TestAccStoragePool_target(t *testing.T) {
 }
 
 func TestAccStoragePool_importBasic(t *testing.T) {
-	poolName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 	driverName := "zfs"
 	resourceName := "lxd_storage_pool.storage_pool1"
 
@@ -253,7 +252,7 @@ func TestAccStoragePool_importBasic(t *testing.T) {
 }
 
 func TestAccStoragePool_importConfig(t *testing.T) {
-	poolName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 	driverName := "zfs"
 	resourceName := "lxd_storage_pool.storage_pool1"
 
@@ -276,8 +275,8 @@ func TestAccStoragePool_importConfig(t *testing.T) {
 }
 
 func TestAccStoragePool_importProject(t *testing.T) {
-	poolName := petname.Generate(2, "-")
-	projectName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 	driverName := "zfs"
 	resourceName := "lxd_storage_pool.storage_pool1"
 

--- a/internal/storage/resource_storage_volume_copy_test.go
+++ b/internal/storage/resource_storage_volume_copy_test.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccStorageVolumeCopy_basic(t *testing.T) {
-	poolName := petname.Generate(2, "-")
-	volumeName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
+	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },

--- a/internal/storage/resource_storage_volume_test.go
+++ b/internal/storage/resource_storage_volume_test.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
 func TestAccStorageVolume_basic(t *testing.T) {
-	poolName := petname.Generate(2, "-")
-	volumeName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
+	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -33,9 +32,9 @@ func TestAccStorageVolume_basic(t *testing.T) {
 }
 
 func TestAccStorageVolume_instanceAttach(t *testing.T) {
-	instanceName := petname.Generate(2, "-")
-	poolName := petname.Generate(2, "-")
-	volumeName := petname.Generate(2, "-")
+	instanceName := acctest.GenerateName(2, "-")
+	poolName := acctest.GenerateName(2, "-")
+	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -63,7 +62,7 @@ func TestAccStorageVolume_instanceAttach(t *testing.T) {
 }
 
 func TestAccStorageVolume_target(t *testing.T) {
-	volumeName := petname.Generate(2, "-")
+	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -85,8 +84,8 @@ func TestAccStorageVolume_target(t *testing.T) {
 }
 
 func TestAccStorageVolume_project(t *testing.T) {
-	volumeName := petname.Generate(2, "-")
-	projectName := petname.Name()
+	volumeName := acctest.GenerateName(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -106,8 +105,8 @@ func TestAccStorageVolume_project(t *testing.T) {
 }
 
 func TestAccStorageVolume_contentType(t *testing.T) {
-	poolName := petname.Generate(2, "-")
-	volumeName := petname.Generate(2, "-")
+	poolName := acctest.GenerateName(2, "-")
+	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -128,8 +127,8 @@ func TestAccStorageVolume_contentType(t *testing.T) {
 }
 
 func TestAccStorageVolume_importBasic(t *testing.T) {
-	volName := petname.Generate(2, "-")
-	poolName := petname.Generate(2, "-")
+	volName := acctest.GenerateName(2, "-")
+	poolName := acctest.GenerateName(2, "-")
 	resourceName := "lxd_volume.volume1"
 
 	resource.Test(t, resource.TestCase{
@@ -151,8 +150,8 @@ func TestAccStorageVolume_importBasic(t *testing.T) {
 }
 
 func TestAccStorageVolume_importProject(t *testing.T) {
-	volName := petname.Generate(2, "-")
-	projectName := petname.Generate(2, "-")
+	volName := acctest.GenerateName(2, "-")
+	projectName := acctest.GenerateName(2, "-")
 	resourceName := "lxd_volume.volume1"
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Occasionally the tests fail because the duplicate name gets generated for multiple test resources of the same type. This PR just wraps the `petname.Generate()` and generates a random string suffix if requested word count is more then 1.