### PR TITLE
expose new ipv4_addresses and ipv6_addresses computed attributes on i…

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -182,7 +182,13 @@ The following attributes are exported:
 * `ipv4_address` - The IPv4 Address of the instance. See Instance Network
   Access for more details.
 
+* `ipv4_addresses` - The IPv4 Addresses of the instance. See Instance Network
+  Access for more details.
+
 * `ipv6_address` - The IPv6 Address of the instance. See Instance Network
+  Access for more details.
+
+* `ipv6_addresses` - The IPv6 Addresses of the instance. See Instance Network
   Access for more details.
 
 * `mac_address` - The MAC address of the detected NIC. See Instance Network
@@ -217,8 +223,12 @@ resource "lxd_instance" "inst" {
 ## Instance Network Access
 
 If your instance has multiple network interfaces, you can specify which one
-Terraform should report the IP addresses of. If you do not specify an interface,
+Terraform should report the IP address of. If you do not specify an interface,
 Terraform will use the _last_ address detected. Global IPv6 address will be favored if present.
+
+The `ipv4_addresses` and `ipv6_addresses` attributes provide a list of all IP addresses
+available either on the system, or if `user.access_interface` is specified, on a specific
+interface.
 
 To specify an interface, do the following:
 


### PR DESCRIPTION
…nstance resources

resolves #321 - see motivation and reasoning in linked issue... but basically multiple ip addresses assigned to a single interface is something the current provider does not cover

how it looks when 2 ipv6 addresses are assigned to a single interface:
```
aanderse@obsidian ~> jq '.lxd_instance.dash' resources.json
{
  "config": {
    "boot.autostart": "true"
  },
  "description": "",
  "device": [],
  "ephemeral": false,
  "execs": null,
  "file": [],
  "image": "nixos",
  "ipv4_address": "10.30.10.227",
  "ipv6_address": "2a01:4f8:242:5e07:216:3eff:fe67:ba0f",
  "ipv6_addresses": [
    "fd23:cafe:618:0:216:3eff:fe67:ba0f",
    "2a01:4f8:242:5e07:216:3eff:fe67:ba0f"
  ],
  "limits": {},
  "mac_address": "00:16:3e:67:ba:0f",
  "name": "dash",
  "profiles": [
    "default"
  ],
  "project": "sky",
  "remote": null,
  "running": true,
  "status": "Running",
  "target": "618-fsn1-dc15-hetz",
  "timeouts": null,
  "type": "container",
  "wait_for_network": true
}
```

i've never written or contributed to a `terraform` provider before so please let me know if i've completely missed anything obvious here...

thank you for your time and any potential reviews