### PR TITLE
Fully resolve `configDir` before using it

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -150,10 +150,11 @@ func (p *LxdProvider) Configure(ctx context.Context, req provider.ConfigureReque
 			configDir = "$HOME/.config/lxc"
 		}
 	}
+	configDir = os.ExpandEnv(configDir)
 
 	// Try to load config.yml from determined configDir. If there's
 	// an error loading config.yml, default config will be used.
-	configPath := os.ExpandEnv(filepath.Join(configDir, "config.yml"))
+	configPath := filepath.Join(configDir, "config.yml")
 	config, err := lxd_config.LoadConfig(configPath)
 	if err != nil {
 		config = lxd_config.DefaultConfig()


### PR DESCRIPTION
I noticed that I had a directory in the root of my Terraform module named, literally, `$HOME`, that contained certs for my LXD server.

```
$ ls -lah \$HOME/.config/lxc/
total 16
drwxr-x---@ 5 seth  staff   160B Mar 19 15:31 .
drwxr-x---@ 3 seth  staff    96B Mar 19 15:31 ..
-rw-r--r--@ 1 seth  staff   684B Mar 19 15:31 client.crt
-rw-------@ 1 seth  staff   288B Mar 19 15:31 client.key
drwxr-x---@ 3 seth  staff    96B Mar 19 15:31 servercerts
```

It turns out that `config.ConfigDir` is set to the unexpanded value of `configDir` ([here](https://github.com/terraform-lxd/terraform-provider-lxd/blob/56c3a89362848fcab616c7ebc7027bd32b38ae9b/internal/provider/provider.go#L160)), which the lxd package happily uses as a literal path in the current directory. The solution is to simply expand it before use, instead of in the `configPath` assignment.