### PR TITLE
Expand ConfigDir env vars when config.yml is missing

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -151,9 +151,11 @@ func (p *LxdProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		}
 	}
 
+	configDir = os.ExpandEnv(configDir)
+
 	// Try to load config.yml from determined configDir. If there's
 	// an error loading config.yml, default config will be used.
-	configPath := os.ExpandEnv(filepath.Join(configDir, "config.yml"))
+	configPath := filepath.Join(configDir, "config.yml")
 	config, err := lxd_config.LoadConfig(configPath)
 	if err != nil {
 		config = lxd_config.DefaultConfig()


### PR DESCRIPTION
Cherry picked from https://github.com/lxc/terraform-provider-incus/pull/20