### PR TITLE
Export instance's network interfaces

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -179,14 +179,16 @@ The `execs` map elements support the following attributes:
 
 The following attributes are exported:
 
-* `ipv4_address` - The IPv4 Address of the instance. See Instance Network
+* `ipv4_address` - The instance's global IPv4 address. See Instance Network
   Access for more details.
 
-* `ipv6_address` - The IPv6 Address of the instance. See Instance Network
+* `ipv6_address` - The instance's global IPv6 address. See Instance Network
   Access for more details.
 
-* `mac_address` - The MAC address of the detected NIC. See Instance Network
+* `mac_address` - The MAC address of the network interface. If MAC address is not available, the instance has no global IP address. See Instance Network
   Access for more details.
+
+* `interfaces` - Map of all instance network interfaces (excluding loopback device). The map key represents the name of the network device (from LXD configuration).
 
 * `status` - The status of the instance.
 

--- a/internal/common/lxd_interface.go
+++ b/internal/common/lxd_interface.go
@@ -1,0 +1,111 @@
+package common
+
+import (
+	"context"
+	"strings"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Interface represents LXD instance network interface.
+type InterfaceModel struct {
+	// Real name of the interface within the instance. If config interface is
+	// defined as "eth0", the real interface within a container will have the
+	// same name. However, VMs will most likely have enp0sX.
+	RealName types.String `tfsdk:"name"`
+
+	// State of the interface [UP, DOWN].
+	State types.String `tfsdk:"state"`
+
+	// Type of the interface [broadcast, loopback].
+	Type types.String `tfsdk:"type"`
+
+	// List of interface addresses.
+	Addresses types.List `tfsdk:"ips"`
+}
+
+// Interface IP is a wrapper of the interface IP address.
+type IPModel struct {
+	// IP address.
+	Address types.String `tfsdk:"address"`
+
+	// Family [inet, inet6].
+	Family types.String `tfsdk:"family"`
+
+	// Scope [link, local, global].
+	Scope types.String `tfsdk:"scope"`
+}
+
+// ToInterfaceMapType converts provided intance networks into types.Map. The function
+// also accepts instance config which is used to determine configuration interface name.
+func ToInterfaceMapType(ctx context.Context, instNetworks map[string]api.InstanceStateNetwork, instConfig map[string]string) (types.Map, diag.Diagnostics) {
+	ipType := map[string]attr.Type{
+		"address": types.StringType,
+		"family":  types.StringType,
+		"scope":   types.StringType,
+	}
+
+	infType := map[string]attr.Type{
+		"name":  types.StringType,
+		"state": types.StringType,
+		"type":  types.StringType,
+		"ips":   types.ListType{ElemType: types.ObjectType{AttrTypes: ipType}},
+	}
+
+	nilMap := types.MapNull(types.ObjectType{AttrTypes: infType})
+	if len(instNetworks) == 0 {
+		return nilMap, nil
+	}
+
+	interfaces := make(map[string]InterfaceModel, len(instNetworks))
+	for name, net := range instNetworks {
+		// Find volatile entry that contains mac address of the network
+		// interface. If addresses match, extract the config name of the
+		// interface from the config key (volatile.<if_name>.hwaddr).
+		cfgInfName := ""
+		for k, v := range instConfig {
+			if v == net.Hwaddr {
+				cfgInfName = strings.SplitN(k, ".", 3)[1]
+				break
+			}
+		}
+
+		if cfgInfName == "" {
+			// We did not find a matching config interface, therefore
+			// do not export it.
+			continue
+		}
+
+		// Interface metadata.
+		inf := InterfaceModel{
+			RealName: types.StringValue(name),
+			State:    types.StringValue(net.State),
+			Type:     types.StringValue(net.Type),
+		}
+
+		// Interface addresses.
+		netAddresses := make([]IPModel, 0, len(net.Addresses))
+		for _, addr := range net.Addresses {
+			addrType := IPModel{
+				Address: types.StringValue(addr.Address),
+				Family:  types.StringValue(addr.Family),
+				Scope:   types.StringValue(addr.Scope),
+			}
+
+			netAddresses = append(netAddresses, addrType)
+		}
+
+		addresses, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: ipType}, netAddresses)
+		if diags.HasError() {
+			return nilMap, diags
+		}
+
+		inf.Addresses = addresses
+		interfaces[cfgInfName] = inf
+	}
+
+	return types.MapValueFrom(ctx, types.ObjectType{AttrTypes: infType}, interfaces)
+}

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -1063,43 +1063,45 @@ func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, s
 	m.IPv6 = types.StringNull()
 	m.MAC = types.StringNull()
 
-	// First there is an access_interface set, extract IPv4, IPv4, and
-	// MAC addresses from it.
-	var accIfaceFound bool
 	accIface, ok := instance.ExpandedConfig["user.access_interface"]
 	if ok {
-		net := instanceState.Network[accIface]
-
-		ipv4, mac, ok := findIPv4Address(net)
+		// If there is an user.access_interface set, extract IPv4, IPv6 and
+		// MAC addresses from that network interface.
+		net, ok := instanceState.Network[accIface]
 		if ok {
-			m.IPv4 = types.StringValue(ipv4)
-			m.MAC = types.StringValue(mac)
-			accIfaceFound = true
-		}
+			m.MAC = types.StringValue(net.Hwaddr)
+			ipv4, ipv6 := findGlobalIPAddresses(net)
 
-		ipv6, ok := findIPv6Address(net)
-		if ok {
-			m.IPv6 = types.StringValue(ipv6)
-		}
-	}
+			if ipv4 != "" {
+				m.IPv4 = types.StringValue(ipv4)
+			}
 
-	// If the above wasn't successful, try to automatically determine
-	// the IPv4, IPv6, and MAC addresses.
-	if !accIfaceFound {
-		for iface, net := range instanceState.Network {
+			if ipv6 != "" {
+				m.IPv6 = types.StringValue(ipv6)
+			}
+		}
+	} else {
+		// Search for the first interface (alphabetically sorted) that has
+		// global IPv4 or IPv6 address.
+		for _, iface := range utils.SortMapKeys(instanceState.Network) {
 			if iface == "lo" {
 				continue
 			}
 
-			ipv4, mac, ok := findIPv4Address(net)
-			if ok {
-				m.IPv4 = types.StringValue(ipv4)
-				m.MAC = types.StringValue(mac)
-			}
+			net := instanceState.Network[iface]
+			ipv4, ipv6 := findGlobalIPAddresses(net)
+			if ipv4 != "" || ipv6 != "" {
+				m.MAC = types.StringValue(net.Hwaddr)
 
-			ipv6, ok := findIPv6Address(net)
-			if ok {
-				m.IPv6 = types.StringValue(ipv6)
+				if ipv4 != "" {
+					m.IPv4 = types.StringValue(ipv4)
+				}
+
+				if ipv6 != "" {
+					m.IPv6 = types.StringValue(ipv6)
+				}
+
+				break
 			}
 		}
 	}
@@ -1370,41 +1372,23 @@ func isInstanceStopped(s api.InstanceState) bool {
 	return s.StatusCode == api.Stopped
 }
 
-// findIPv4Address searches the network for last IPv4 address. If an IP address
-// is found, interface's MAC address is also returned.
-func findIPv4Address(network api.InstanceStateNetwork) (string, string, bool) {
-	var ipv4, mac string
+// findGlobalIPAddresses returns first global IPv4 and IPv6 addresses of the
+// provided network interface. If an IP address is not found, an empty string
+// is returned.
+func findGlobalIPAddresses(network api.InstanceStateNetwork) (ipv4 string, ipv6 string) {
 	for _, ip := range network.Addresses {
-		if ip.Family == "inet" {
-			ipv4 = ip.Address
-			mac = network.Hwaddr
+		if ip.Scope != "global" {
+			continue
 		}
-	}
 
-	return ipv4, mac, (ipv4 != "")
-}
+		if ipv4 == "" && ip.Family == "inet" {
+			ipv4 = ip.Address
+		}
 
-// Find last global IPv6 address or return any last IPv6 address
-// if there is no global address. This works analog to the IPv4
-// selection mechanism but favors global addresses.
-func findIPv6Address(network api.InstanceStateNetwork) (string, bool) {
-	var ipv6 string
-
-	for _, ip := range network.Addresses {
-		if ip.Family == "inet6" && ip.Scope == "global" {
+		if ipv6 == "" && ip.Family == "inet6" {
 			ipv6 = ip.Address
 		}
 	}
 
-	if ipv6 != "" {
-		return ipv6, true
-	}
-
-	for _, ip := range network.Addresses {
-		if ip.Family == "inet6" {
-			return ip.Address, true
-		}
-	}
-
-	return ipv6, (ipv6 != "")
+	return ipv4, ipv6
 }


### PR DESCRIPTION
Export map of network interfaces as an instance attribute. The map key represents the network device name (from LXD configuration).

In addition, attributes `ipv4_address` and `ipv6_address` are now exported from the same interface and only global IPs are exported. The IPs are retrieved from the first network interface (sorted alphabetically) that contains at least one global IP.

Fixes #453
Fixes #321
Closes #427