### PR TITLE
Add support for custom simplestreams remote

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 The `remote` block supports:
 
-* `address` - *Optional* - The address of the LXD remote.
+* `address` - *Optional* - The address of the remote.
 
 * `default` - *Optional* - Whether this should be the default remote.
 	This remote will then be used when one is not specified in a resource.
@@ -88,14 +88,16 @@ The `remote` block supports:
 	for more information.
 	The default can also be set with the `LXD_REMOTE` Environment variable.
 
-* `name` - *Optional* - The name of the LXD remote.
+* `name` - *Optional* - The name of the remote.
 
 * `password` - *Optional* - The password to authenticate to the LXD remote.
 
-* `port` - *Optional* - The port of the LXD remote.
+* `port` - *Optional* - The port of the remote.
 
-* `scheme` - *Optional* Whether to connect to the LXD remote via `https` or
-	`unix` (UNIX socket). Defaults to `unix`.
+* `protocol` - *Optional* - The protocol of remote server (`lxd` or `simplestreams`).
+
+* `scheme` - *Optional* Whether to connect to the remote via `https` or
+	`unix` (UNIX socket). Defaults to `unix` for LXD remote and `https` for simplestreams remote.
 
 ## Undefined Remote
 

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -1168,6 +1168,24 @@ func TestAccInstance_removeProject(t *testing.T) {
 	})
 }
 
+func TestAccInstance_customImageServer(t *testing.T) {
+	instanceName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_customImageServer(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccInstance_timeout(t *testing.T) {
 	instanceName := acctest.GenerateName(2, "-")
 
@@ -2035,6 +2053,23 @@ resource "lxd_instance" "instance1" {
   image = "%s"
 }
 	`, projectName, instanceName, acctest.TestImage)
+}
+
+func testAccInstance_customImageServer(instanceName string) string {
+	return fmt.Sprintf(`
+provider "lxd" {
+  remote {
+    name     = "images-temporary"
+    address  = "images.lxd.canonical.com"
+    protocol = "simplestreams"
+  }
+}
+
+resource "lxd_instance" "instance1" {
+  name  = "%s"
+  image = "images-temporary:alpine/edge"
+}
+	`, instanceName)
 }
 
 func testAccInstance_timeout(instanceName string) string {

--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -28,6 +28,7 @@ type LxdProviderRemoteConfig struct {
 	Address      string
 	Port         string
 	Password     string
+	Protocol     string
 	Scheme       string
 	Bootstrapped bool
 }
@@ -201,15 +202,14 @@ func (p *LxdProviderConfig) createLxdServerClient(remote LxdProviderRemoteConfig
 		return nil
 	}
 
-	daemonAddr, err := determineLxdDaemonAddr(remote)
-	if err != nil {
-		return fmt.Errorf("Unable to determine daemon address for remote %q: %v", remote.Name, err)
+	lxdRemote := lxd_config.Remote{
+		Addr:     determineLxdDaemonAddr(remote),
+		Protocol: remote.Protocol,
 	}
 
-	lxdRemote := lxd_config.Remote{Addr: daemonAddr}
 	p.setLxdConfigRemote(remote.Name, lxdRemote)
 
-	if remote.Scheme == "https" {
+	if remote.Scheme == "https" && remote.Protocol == "lxd" {
 		// If the LXD remote's certificate does not exist on the client...
 		p.mux.RLock()
 		certPath := p.lxdConfig.ServerCertPath(remote.Name)
@@ -364,7 +364,7 @@ func connectToLxdServer(instServer lxd.InstanceServer) error {
 }
 
 // determineLxdDaemonAddr determines address of the LXD server daemon.
-func determineLxdDaemonAddr(remote LxdProviderRemoteConfig) (string, error) {
+func determineLxdDaemonAddr(remote LxdProviderRemoteConfig) string {
 	var daemonAddr string
 
 	if remote.Address != "" {
@@ -376,7 +376,7 @@ func determineLxdDaemonAddr(remote LxdProviderRemoteConfig) (string, error) {
 		}
 	}
 
-	return daemonAddr, nil
+	return daemonAddr
 }
 
 // determineLxdDir determines which standard LXD directory contains a writable UNIX socket.


### PR DESCRIPTION
Currently, only LXD remote can be added in provider configuration. This PR enables adding custom simplestreams remote.