### PR TITLE
Fix storage pool source inconsistencies

### DIFF
--- a/docs/resources/storage_pool.md
+++ b/docs/resources/storage_pool.md
@@ -10,9 +10,6 @@ Manages an LXD storage pool.
 resource "lxd_storage_pool" "pool1" {
   name   = "mypool"
   driver = "dir"
-  config = {
-    source = "/var/lib/lxd/storage-pools/mypool"
-  }
 }
 ```
 
@@ -53,7 +50,12 @@ for more details on how to create a storage pool in clustered mode.
 
 * `name`   - **Required** - Name of the storage pool.
 
-* `driver` - **Required** - Storage Pool driver. Must be one of `dir`, `zfs`, `lvm`, `btrfs`, `ceph`, `cephfs`, or `cephobject`.
+* `driver` - **Required** - Storage pool driver. Must be one of `dir`, `zfs`, `lvm`, `btrfs`, `ceph`, `cephfs`, or `cephobject`.
+
+* `source` - *Optional* - Source of the storage pool that is applicable only during the creation.
+  While this corresponds to `config.source` in LXD, `config.source` is adjusted after creation by
+  LXD based on the underlying storage driver. Therefore, using `source` during creation prevents an
+  inconsistent Terraform plan.
 
 * `description` - *Optional* - Description of the storage pool.
 

--- a/internal/acctest/checks.go
+++ b/internal/acctest/checks.go
@@ -2,6 +2,7 @@ package acctest
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -96,6 +97,16 @@ func PreCheckClustering(t *testing.T) {
 
 	if !server.IsClustered() {
 		t.Skipf("Test %q skipped. LXD server is not running in clustered mode.", t.Name())
+	}
+}
+
+// PreCheckRoot skips the test if the user cannot escalate privileges without a password.
+// Root is required for certain tests, such as creating a loopback device for storage.
+// This ensures tests do not stop midway asking for password.
+func PreCheckRoot(t *testing.T) {
+	err := exec.Command("sudo", "-n", "true").Run()
+	if err != nil {
+		t.Skipf("Test %q skipped. Cannot escalate privilege without a password.", t.Name())
 	}
 }
 

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -6,6 +6,7 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -112,6 +113,9 @@ func (r StoragePoolResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Computed:    true,
 				ElementType: types.StringType,
 				Default:     mapdefault.StaticValue(types.MapValueMust(types.StringType, map[string]attr.Value{})),
+				Validators: []validator.Map{
+					mapvalidator.KeysAre(configSourceValidator{}),
+				},
 			},
 		},
 	}

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -28,6 +28,7 @@ type StoragePoolModel struct {
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 	Driver      types.String `tfsdk:"driver"`
+	Source      types.String `tfsdk:"source"`
 	Project     types.String `tfsdk:"project"`
 	Target      types.String `tfsdk:"target"`
 	Remote      types.String `tfsdk:"remote"`
@@ -72,6 +73,11 @@ func (r StoragePoolResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Validators: []validator.String{
 					stringvalidator.OneOf("dir", "zfs", "lvm", "btrfs", "ceph", "cephfs", "cephobject"),
 				},
+			},
+
+			"source": schema.StringAttribute{
+				Description: "Source of the storage pool which is respected only when the storage pool is being created.",
+				Optional:    true,
 			},
 
 			"project": schema.StringAttribute{
@@ -149,6 +155,12 @@ func (r StoragePoolResource) Create(ctx context.Context, req resource.CreateRequ
 	resp.Diagnostics.Append(diag...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// If storage pool source is configured, set it in the storage pool config.
+	poolSource := plan.Source.ValueString()
+	if poolSource != "" {
+		config["source"] = poolSource
 	}
 
 	pool := api.StoragePoolsPost{

--- a/internal/storage/resource_storage_pool_test.go
+++ b/internal/storage/resource_storage_pool_test.go
@@ -1,7 +1,12 @@
 package storage_test
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -176,6 +181,42 @@ func TestAccStoragePool_config(t *testing.T) {
 	})
 }
 
+func TestAccStoragePool_configSource(t *testing.T) {
+	drivers := []string{"dir", "zfs", "btrfs", "lvm"}
+
+	// Skip test if we have no root permissions. Root permissions are required
+	// for creating loopback devices.
+	acctest.PreCheckRoot(t)
+
+	for _, poolDriver := range drivers {
+		poolName := acctest.GenerateName(2, "-")
+		poolSource, cleanup := ensureSource(t, poolDriver)
+
+		t.Run(fmt.Sprintf("%s[%s]", t.Name(), poolDriver), func(t *testing.T) {
+			defer cleanup()
+			resource.Test(t, resource.TestCase{
+				PreCheck:                 func() { acctest.PreCheck(t) },
+				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: testAccStoragePool_configSource(poolName, poolDriver, poolSource),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "name", poolName),
+							resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "driver", poolDriver),
+							resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "source", poolSource),
+							resource.TestCheckNoResourceAttr("lxd_storage_pool.storage_pool1", "config.source"),
+						),
+					},
+					{
+						// Reapply the same config to ensure there is no drift in terraform state.
+						Config: testAccStoragePool_configSource(poolName, poolDriver, poolSource),
+					},
+				},
+			})
+		})
+	}
+}
+
 func TestAccStoragePool_project(t *testing.T) {
 	poolName := acctest.GenerateName(2, "-")
 	projectName := acctest.GenerateName(2, "-")
@@ -319,6 +360,16 @@ resource "lxd_storage_pool" "storage_pool1" {
 	`, name, driver)
 }
 
+func testAccStoragePool_configSource(name string, driver string, source string) string {
+	return fmt.Sprintf(`
+resource "lxd_storage_pool" "storage_pool1" {
+  name   = "%s"
+  driver = "%s"
+  source = "%s"
+}
+	`, name, driver, source)
+}
+
 func testAccStoragePool_project(name string, driver string, project string) string {
 	return fmt.Sprintf(`
 resource "lxd_project" "project1" {
@@ -361,4 +412,63 @@ resource "lxd_storage_pool" "storage_pool1" {
   driver = "%[2]s"
 }
 	`, name, driver)
+}
+
+// ensureSource ensures temporary storage pool source is created based on the provided
+// storage pool driver. For "dir", a temporary directory is created. For "zfs", "lvm",
+// and "btrfs" a loopback device pointing to a temporary file is created.
+func ensureSource(t *testing.T, driver string) (source string, cleanup func()) {
+	switch driver {
+	case "dir":
+		// For directory storage driver, just create an empty directory.
+
+		source = filepath.Join(os.TempDir(), "tf-storage-pool-dir")
+		_ = os.RemoveAll(source)
+
+		err := os.Mkdir(source, os.ModePerm)
+		if err != nil {
+			t.Fatalf("Failed to create temporary directory: %v", err)
+		}
+
+		cleanup = func() {
+			_ = os.RemoveAll(source)
+		}
+	case "zfs", "btrfs", "lvm":
+		// For zfs, btrfs, and lvm storage drivers, create a temporary file
+		// and attach it as a loopback device.
+
+		disk, err := os.CreateTemp(os.TempDir(), "tf-storage-pool-disk-*")
+		if err != nil {
+			t.Fatalf("Failed to create temporary disk file: %v", err)
+		}
+		defer disk.Close()
+
+		err = disk.Truncate(128 * 1024 * 1024) // 128 MiB
+		if err != nil {
+			t.Fatalf("Failed to truncate temporary disk file: %v", err)
+		}
+
+		// Create the loopback device.
+		var bufOut, bufErr bytes.Buffer
+		cmd := exec.Command("sudo", "losetup", "-fP", "--show", disk.Name())
+		cmd.Stdout = &bufOut
+		cmd.Stderr = &bufErr
+		err = cmd.Run()
+		if err != nil {
+			t.Fatalf("Failed to create loopback device (%v): %s", err, bufErr.String())
+		}
+
+		// Retrieve the loopback device name.
+		source = strings.TrimSpace(bufOut.String())
+
+		cleanup = func() {
+			// Detach loopback device and remove temporary file.
+			_ = exec.Command("sudo", "losetup", "-d", source).Run()
+			_ = os.RemoveAll(disk.Name())
+		}
+	default:
+		t.Fatalf("Cannot create source for storage driver %q", driver)
+	}
+
+	return source, cleanup
 }

--- a/internal/storage/resource_storage_pool_test.go
+++ b/internal/storage/resource_storage_pool_test.go
@@ -214,8 +214,8 @@ func TestAccStoragePool_target(t *testing.T) {
 			{
 				Config: testAccStoragePool_target(poolName, driverName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node2", "name", poolName),
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node2", "driver", driverName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node1", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node1", "driver", driverName),
 					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node1", "target", "node-1"),
 					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node2", "name", poolName),
 					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node2", "driver", driverName),

--- a/internal/storage/schema_validators.go
+++ b/internal/storage/schema_validators.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// configSourceValidator ensures storage pool source in configuration is treated as
+// read-only attribute.
+type configSourceValidator struct{}
+
+func (v configSourceValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("config key %q is read-only", "source")
+}
+func (v configSourceValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("config key `%s` is read-only", "source")
+}
+
+func (v configSourceValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	value := req.ConfigValue.ValueString()
+
+	if value == "source" {
+		resp.Diagnostics.AddAttributeError(req.Path, "Invalid config key", fmt.Sprint(
+			`Setting storage pool source using "config.source" is not allowed, `+
+				`as it will produce an inconsistent Terraform plan. Use "source" `+
+				`attribute instead which will be respected only during the `+
+				`creation of the storage pool.`),
+		)
+	}
+}


### PR DESCRIPTION
The `config.source` field for storage pools is adjusted by LXD during creation of the storage pool based on the used storage pool driver.

For example, using a loopback device `/dev/loop26` as a `config.source` when creating a storage pool `data1` results in the following values for the given drivers:

- `zfs` -> `data1`
- `lvm` -> `data1`
- `btrfs` -> `62d9e038-0f21-4e5c-9ecc-07514e894b45`
- `dir` -> `/path/to/disk` (used actual path instead of loop device)

For `dir` storage driver, the source remains the same. For `zfs` and `lvm`, the source is predictable (name of the storage pool). However, for `btrfs`, the source is unpredictable and cannot be *planned* ahead of time. This causes inconsistencies in Terraform plan.

This PR introduces additional attribute `source` for storage pool resource that is respected only during the creation of the storage pool.

Example:
```hcl
resource "lxd_storage_pool" "data1" {
  name   = "data1"
  driver = "btrfs"
  source = "/dev/loop26"
}
```

Fixes #432