### PR TITLE
Do not error out if client certificate already exists

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -13,6 +13,11 @@ func IsNotFoundError(err error) bool {
 	return api.StatusErrorCheck(err, http.StatusNotFound)
 }
 
+// IsConflictError checks whether the given error is of type Conflict.
+func IsConflictError(err error) bool {
+	return api.StatusErrorCheck(err, http.StatusConflict)
+}
+
 // NewInstanceServerError converts an error into diagnostic indicating
 // that provider failed to retrieve LXD instance server client.
 func NewInstanceServerError(err error) diag.Diagnostic {

--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -12,6 +12,7 @@ import (
 	lxd_config "github.com/canonical/lxd/lxc/config"
 	lxd_shared "github.com/canonical/lxd/shared"
 	lxd_api "github.com/canonical/lxd/shared/api"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/errors"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/utils"
 )
 
@@ -335,8 +336,9 @@ func authenticateToLxdServer(instServer lxd.InstanceServer, password string) err
 	req.Password = password
 	req.Type = "client"
 
+	// Create new certificate. Ignore error of type conflict (certificate already exists).
 	err = instServer.CreateCertificate(req)
-	if err != nil {
+	if err != nil && !errors.IsConflictError(err) {
 		return fmt.Errorf("Unable to authenticate with remote server: %v", err)
 	}
 


### PR DESCRIPTION
If client certificate already exists, use it for authentication instead of erroring out with `Certificate already in trust store`.