### PR TITLE
Add support for client certificates

### DIFF
--- a/docs/resources/trust_certificate.md
+++ b/docs/resources/trust_certificate.md
@@ -1,0 +1,46 @@
+# lxd_trust_certificate
+
+The `lxd_trust_certificate` resource allows you to register new client certificates in the LXD trust store.
+
+## Example Usage
+
+```hcl
+resource "lxd_trust_certificate" "cert1" {
+  name = "cert1"
+  path = "/path/to/cert"
+}
+
+resource "lxd_trust_certificate" "cert2" {
+  name    = "cert2"
+  content = <<EOF
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+EOF
+}
+```
+
+## Argument Reference
+
+* `name` - **Required** - Name of the certificate.
+
+* `content` - *__Required__ unless path is used* - The _contents_ of the certificate. Storing the
+        certificate directly in the Terraform configuration as plain text is not recommended. Instead,
+        use the `file()` function to read the content from a file on disk, or use the `path` attribute.
+
+* `path` - *__Required__ unless content is used* - The path to a file containing a certificate.
+
+* `projects` - *Optional* - List of projects to restrict the certificate to.
+
+* `remote` - *Optional* - The remote in which the resource will be created. If
+	not provided, the provider's default remote will be used.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `fingerprint` - The unique hash fingerprint of the certificate.
+
+## Notes
+
+* See the LXD [documentation](https://documentation.ubuntu.com/lxd/en/latest/authentication/#tls-client-certificates) for more information on client certificates.

--- a/docs/resources/trust_certificate.md
+++ b/docs/resources/trust_certificate.md
@@ -24,6 +24,8 @@ EOF
 
 * `name` - **Required** - Name of the certificate.
 
+* `type` - *Optional* - Certificate type. Can be either `client` or `metrics`. Defaults to `client`.
+
 * `content` - *__Required__ unless path is used* - The _contents_ of the certificate. Storing the
         certificate directly in the Terraform configuration as plain text is not recommended. Instead,
         use the `file()` function to read the content from a file on disk, or use the `path` attribute.

--- a/internal/acctest/testutils.go
+++ b/internal/acctest/testutils.go
@@ -1,7 +1,9 @@
 package acctest
 
 import (
+	"fmt"
 	"math/rand/v2"
+	"strings"
 
 	petname "github.com/dustinkirkland/golang-petname"
 )
@@ -25,4 +27,14 @@ func GenerateName(words int, separator string) string {
 	}
 
 	return petname.Generate(words-1, separator) + separator + generateString(6)
+}
+
+// QuoteStrings converts slice of strings into a single string where each slice
+// element is quoted and delimited with a comma and whitespace.
+func QuoteStrings(slice []string) string {
+	quoted := make([]string, len(slice))
+	for i, s := range slice {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return strings.Join(quoted, ", ")
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/project"
 	provider_config "github.com/terraform-lxd/terraform-provider-lxd/internal/provider-config"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/storage"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/truststore"
 )
 
 // LxdProviderRemoteModel represents provider's schema remote.
@@ -310,6 +311,7 @@ func (p *LxdProvider) Resources(_ context.Context) []func() resource.Resource {
 		storage.NewStoragePoolResource,
 		storage.NewStorageVolumeResource,
 		storage.NewStorageVolumeCopyResource,
+		truststore.NewTrustCertificateResource,
 	}
 }
 

--- a/internal/truststore/trust_certificate.go
+++ b/internal/truststore/trust_certificate.go
@@ -1,0 +1,347 @@
+package truststore
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	lxd "github.com/canonical/lxd/client"
+	lxd_shared "github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/errors"
+	provider_config "github.com/terraform-lxd/terraform-provider-lxd/internal/provider-config"
+)
+
+type TrustCertificateModel struct {
+	Name     types.String `tfsdk:"name"`
+	Path     types.String `tfsdk:"path"`
+	Content  types.String `tfsdk:"content"`
+	Projects types.List   `tfsdk:"projects"`
+	Remote   types.String `tfsdk:"remote"`
+
+	// Computed.
+	Fingerprint types.String `tfsdk:"fingerprint"`
+}
+
+// TrustCertificateResource represent LXD trust certificate resource.
+type TrustCertificateResource struct {
+	provider *provider_config.LxdProviderConfig
+}
+
+// NewTrustCertificateResource returns a new trust certificate resource.
+func NewTrustCertificateResource() resource.Resource {
+	return &TrustCertificateResource{}
+}
+
+func (r TrustCertificateResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_trust_certificate", req.ProviderTypeName)
+}
+
+func (r TrustCertificateResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the certificate.",
+			},
+
+			"path": schema.StringAttribute{
+				Optional:    true,
+				Description: "Path to the client certificate.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"content": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Content of the client certificate.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(
+						path.MatchRoot("content"),
+						path.MatchRoot("path"),
+					),
+				},
+			},
+
+			"projects": schema.ListAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "List of projects to restrict the certificate to. By default, no restriction applies.",
+				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+				ElementType: types.StringType,
+			},
+
+			"remote": schema.StringAttribute{
+				Optional:    true,
+				Description: "The remote in which the certificate is created. If not provided, the provider's default remote is used.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			// Computed.
+			"fingerprint": schema.StringAttribute{
+				Computed:    true,
+				Description: "Fingerprint of the certificate.",
+			},
+		},
+	}
+}
+
+func (r *TrustCertificateResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.LxdProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+		return
+	}
+
+	r.provider = provider
+}
+
+func (r TrustCertificateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan TrustCertificateModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := plan.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	// Get list of project to restrict the certificate to.
+	certProjects, diags := ToProjectList(ctx, plan.Projects)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get certificate content.
+	certName := plan.Name.ValueString()
+	certPath := plan.Path.ValueString()
+	certContent := []byte(plan.Content.ValueString())
+	if certPath != "" {
+		certContent, err = os.ReadFile(certPath)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Failed to read certificate %q", certName),
+				fmt.Sprintf("Read certificate on path %q: %v", certPath, err),
+			)
+			return
+		}
+	}
+
+	// Parse the certificate.
+	x509Cert, err := ParseCertX509(certContent)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to parse certificate %q", certName), err.Error())
+		return
+	}
+
+	// Calculate certificate fingerprint.
+	plan.Fingerprint = types.StringValue(lxd_shared.CertFingerprint(x509Cert))
+
+	// Create new certificate.
+	cert := api.CertificatesPost{
+		Type:        "client",
+		Name:        certName,
+		Projects:    certProjects,
+		Restricted:  len(certProjects) > 0,
+		Certificate: base64.StdEncoding.EncodeToString(x509Cert.Raw),
+	}
+
+	err = server.CreateCertificate(cert)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to add certificate %q to the trust store", certName), err.Error())
+		return
+	}
+
+	// Update Terraform state.
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r TrustCertificateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state TrustCertificateModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	// Update Terraform state.
+	diags = r.SyncState(ctx, &resp.State, server, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r TrustCertificateResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan TrustCertificateModel
+	var state TrustCertificateModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	certFingerprint := state.Fingerprint.ValueString()
+
+	remote := plan.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	certName := plan.Name.ValueString()
+	cert, etag, err := server.GetCertificate(certFingerprint)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve certificate %q", certName), err.Error())
+		return
+	}
+
+	certProjects, diags := ToProjectList(ctx, plan.Projects)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Update existing certificate.
+	newCert := cert.Writable()
+	newCert.Name = certName
+	newCert.Projects = certProjects
+	newCert.Restricted = len(certProjects) > 0
+
+	err = server.UpdateCertificate(cert.Fingerprint, newCert, etag)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update certificate %q", cert.Name), err.Error())
+		return
+	}
+
+	plan.Fingerprint = state.Fingerprint
+
+	// Update Terraform state.
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r TrustCertificateResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state TrustCertificateModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	fingerprint := state.Fingerprint.ValueString()
+	err = server.DeleteCertificate(fingerprint)
+	if err != nil {
+		if errors.IsNotFoundError(err) {
+			return
+		}
+
+		certName := state.Name.ValueString()
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to remove certificate %q", certName), err.Error())
+	}
+}
+
+// SyncState fetches the server's current state for a certificate and updates
+// the provided model. It then applies this updated model as the new state
+// in Terraform.
+func (r TrustCertificateResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m TrustCertificateModel) diag.Diagnostics {
+	var respDiags diag.Diagnostics
+
+	certName := m.Name.ValueString()
+	certFingerprint := m.Fingerprint.ValueString()
+	cert, _, err := server.GetCertificate(certFingerprint)
+	if err != nil {
+		if errors.IsNotFoundError(err) {
+			tfState.RemoveResource(ctx)
+			return nil
+		}
+
+		respDiags.AddError(fmt.Sprintf("Failed to retrieve certificate %q", certName), err.Error())
+		return respDiags
+	}
+
+	projects, diags := ToProjectListType(ctx, cert.Projects)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Sync all fields except Certificate itself - we do not want to keep it
+	// in Terraform state. If fingerprint changes, we will update the state.
+	m.Name = types.StringValue(cert.Name)
+	m.Fingerprint = types.StringValue(cert.Fingerprint)
+	m.Projects = projects
+
+	return tfState.Set(ctx, &m)
+}
+
+// ToProjectList converts projects from type types.List into []string.
+func ToProjectList(ctx context.Context, projectList types.List) ([]string, diag.Diagnostics) {
+	projects := make([]string, 0, len(projectList.Elements()))
+	diags := projectList.ElementsAs(ctx, &projects, false)
+	return projects, diags
+}
+
+// ToProjectListType converts projects from type []string into types.List.
+func ToProjectListType[T string](ctx context.Context, projects []string) (types.List, diag.Diagnostics) {
+	return types.ListValueFrom(ctx, types.StringType, projects)
+}
+
+// ParseCertX509 decodes bytes into x509.Certificate.
+func ParseCertX509(bytes []byte) (*x509.Certificate, error) {
+	certBlock, _ := pem.Decode(bytes)
+	if certBlock == nil {
+		return nil, fmt.Errorf("Invalid certificate file")
+	}
+
+	return x509.ParseCertificate(certBlock.Bytes)
+}

--- a/internal/truststore/trust_certificate_test.go
+++ b/internal/truststore/trust_certificate_test.go
@@ -25,6 +25,7 @@ func TestAccTrustCertificate_content(t *testing.T) {
 				Config: testAccTrustCertificate_content(certName, cert),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "type", "client"),
 					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "content", cert),
 					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
 					// Ensure path is not set.
@@ -55,9 +56,41 @@ func TestAccTrustCertificate_path(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName),
 					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "path", certPath),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "type", "client"),
 					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
 					// Ensure content is not set.
 					resource.TestCheckNoResourceAttr("lxd_trust_certificate.cert", "content"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTrustCertificate_type(t *testing.T) {
+	certName := acctest.GenerateName(2, "-")
+	cert, fingerprint := generateCert(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustCertificate_type(certName, "client", cert),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "type", "client"),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "content", cert),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "projects.#", "0"),
+				),
+			},
+			{
+				Config: testAccTrustCertificate_type(certName, "metrics", cert),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "type", "metrics"),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "content", cert),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
 				),
 			},
 		},
@@ -144,6 +177,19 @@ resource "lxd_trust_certificate" "cert" {
   projects = [%s]
 }
 	`, name, certPath, acctest.QuoteStrings(projects))
+}
+
+func testAccTrustCertificate_type(name string, certType string, cert string, projects ...string) string {
+	return fmt.Sprintf(`
+resource "lxd_trust_certificate" "cert" {
+  name     = "%s"
+  type     = "%s"
+  content = <<-EOF
+%s
+EOF
+  projects = [%s]
+}
+	`, name, certType, strings.TrimRight(cert, "\n"), acctest.QuoteStrings(projects))
 }
 
 func generateCert(t *testing.T) (certificate string, fingerprint string) {

--- a/internal/truststore/trust_certificate_test.go
+++ b/internal/truststore/trust_certificate_test.go
@@ -1,0 +1,161 @@
+package truststore_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	lxd_shared "github.com/canonical/lxd/shared"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/truststore"
+)
+
+func TestAccTrustCertificate_content(t *testing.T) {
+	certName := acctest.GenerateName(2, "-")
+	cert, fingerprint := generateCert(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustCertificate_content(certName, cert),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "content", cert),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
+					// Ensure path is not set.
+					resource.TestCheckNoResourceAttr("lxd_trust_certificate.cert", "path"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTrustCertificate_path(t *testing.T) {
+	certName := acctest.GenerateName(2, "-")
+	certPath := filepath.Join(t.TempDir(), "client.crt")
+	cert, fingerprint := generateCert(t)
+
+	// Write certificate to a temporary location.
+	err := os.WriteFile(certPath, []byte(cert), os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to write temporary certificate file: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustCertificate_path(certName, certPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "path", certPath),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
+					// Ensure content is not set.
+					resource.TestCheckNoResourceAttr("lxd_trust_certificate.cert", "content"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTrustCertificate_rename(t *testing.T) {
+	certName1 := acctest.GenerateName(2, "-")
+	certName2 := acctest.GenerateName(2, "-")
+	cert, fingerprint := generateCert(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustCertificate_content(certName1, cert),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName1),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "content", cert),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
+				),
+			},
+			{
+				Config: testAccTrustCertificate_content(certName2, cert),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName2),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "content", cert),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTrustCertificate_restricted(t *testing.T) {
+	certName := acctest.GenerateName(2, "-")
+	cert, fingerprint := generateCert(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrustCertificate_content(certName, cert),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "content", cert),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "projects.#", "0"),
+				),
+			},
+			{
+				Config: testAccTrustCertificate_content(certName, cert, "default"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "name", certName),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "content", cert),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "fingerprint", fingerprint),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "projects.#", "1"),
+					resource.TestCheckResourceAttr("lxd_trust_certificate.cert", "projects.0", "default"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTrustCertificate_content(name string, cert string, projects ...string) string {
+	return fmt.Sprintf(`
+resource "lxd_trust_certificate" "cert" {
+  name    = "%s"
+  content = <<-EOF
+%s
+EOF
+  projects = [%s]
+}
+	`, name, strings.TrimRight(cert, "\n"), acctest.QuoteStrings(projects))
+}
+
+func testAccTrustCertificate_path(name string, certPath string, projects ...string) string {
+	return fmt.Sprintf(`
+resource "lxd_trust_certificate" "cert" {
+  name     = "%s"
+  path     = "%s"
+  projects = [%s]
+}
+	`, name, certPath, acctest.QuoteStrings(projects))
+}
+
+func generateCert(t *testing.T) (certificate string, fingerprint string) {
+	certBytes, _, err := lxd_shared.GenerateMemCert(true, false)
+	if err != nil {
+		t.Fatalf("Failed to generate certificate: %v", err)
+	}
+
+	certX509, err := truststore.ParseCertX509(certBytes)
+	if err != nil {
+		t.Fatalf("Failed to parse generated certificate: %v", err)
+	}
+
+	return string(certBytes), lxd_shared.CertFingerprint(certX509)
+}


### PR DESCRIPTION
Add support for adding client certificates into LXD trust store.

Example:
```hcl
resource "lxd_trust_certificate" "cert" {
  name     = "my-cert"
  type     = "client"         # client or metrics
  path     = "/path/to/cert"
  content = "..."             # Mutually exclusive with "path"
  projects = []               # Projects to restrict the certificate to. Certificate is restricted if len(projects) > 1
  remote   = ""
}
```

Computed field is `fingerprint`.

---

TODO: 
- [x] Agree on naming of the resource - I just went with `trust_certificate`, but this should be changed.
- [x] Docs: Once we agree on naming.

---

Fixes #408