### PR TITLE
Use trust token instead of password for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,12 @@ jobs:
     env:
       TF_ACC: "1"
       GO111MODULE: "on"
-      LXD_REMOTE: local
+      LXD_REMOTE: localhost
+      LXD_SCHEME: https
       LXD_ADDR: localhost
       LXD_PORT: 8443
       LXD_GENERATE_CLIENT_CERTS: "true"
       LXD_ACCEPT_SERVER_CERTIFICATE: "true"
-      LXD_SCHEME: https
-      LXD_PASSWORD: the-password
 
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +51,7 @@ jobs:
         run: |
           sudo snap refresh lxd --channel=${{ matrix.channel }}
           sudo lxd waitready --timeout 60
-          sudo lxd init --auto --trust-password="$LXD_PASSWORD" --network-port="$LXD_PORT" --network-address="$LXD_ADDR"
+          sudo lxd init --auto --network-port="$LXD_PORT" --network-address="$LXD_ADDR"
           sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
 
           # 5.0/* currently use core20 which ships with a buggy lvm2 package so
@@ -64,6 +63,9 @@ jobs:
             sudo snap set lxd lvm.external=true
             sudo snap restart --reload lxd
           fi
+
+          # Generate trust token.
+          echo "LXD_TOKEN=$(lxc config trust add --name lxd-terraform-provider --quiet)" >> $GITHUB_ENV
 
       - name: Configure OVN
         run: |


### PR DESCRIPTION
Generate `LXD_TOKEN` that should be picked by the Terraform provider to authenticate against local LXD server.