### PR TITLE
goreleaser: re-enable arm64 builds for Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: windows
-      goarch: 'arm64'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
I also considered dropping the `arm32` builds for Windows but it seems MS still supports an OS for that CPU arch: https://en.wikipedia.org/wiki/ARM_architecture_family#32-bit_operating_systems