### PR TITLE
Fix cached image being searched only in default project

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -560,10 +560,16 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 		image = imageParts[1]
 	}
 
-	imageServer, err := r.provider.ImageServer(imageRemote)
-	if err != nil {
-		resp.Diagnostics.Append(errors.NewImageServerError(err))
-		return
+	var imageServer lxd.ImageServer
+	if imageRemote == "" {
+		// Use the instance server as an image server if image remote is empty.
+		imageServer = server
+	} else {
+		imageServer, err = r.provider.ImageServer(imageRemote)
+		if err != nil {
+			resp.Diagnostics.Append(errors.NewImageServerError(err))
+			return
+		}
 	}
 
 	// Extract profiles, devices, config and limits.


### PR DESCRIPTION
When image remote is not set, use instance server as an image server.

Previously, when the image server (an actual LXD server) was retrieved, the project was not set. This resulted in images always being searched only in the default project. Now, if image remote is not provided, we use the instance server where the instance is being created as an image server.

Example:
```hcl
resource "lxd_project" "proj" {
  name = "proj"
  config = {
    "features.images"   = true
    "features.profiles" = false
  }
}

resource "lxd_cached_image" "alpine" {
    source_remote = "images"
    source_image  = "alpine/3.18"
    project       = lxd_project.proj.name
}

resource "lxd_instance" "c1" {
    name    = "c1"
    image   = lxd_cached_image.alpine.fingerprint
    project = lxd_project.proj.name
    running = false
}
```

---

Whenever an image remote is set (for example to `local`) the image will be searched in `default` project. 

```hcl
resource "lxd_cached_image" "alpine" {
    source_remote = "images"
    source_image  = "alpine/3.18"
    project       = lxd_project.proj.name
}

resource "lxd_instance" "c1" {
    name    = "c1"
    image   = "local:${lxd_cached_image.alpine.fingerprint}" # Image not found
    project = lxd_project.proj.name
    running = false
}
```
