### PR TITLE
Fix cached image not found if instance remote is set

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -551,16 +551,17 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	var imageRemote string
+	var imageServer lxd.ImageServer
+
 	// Evaluate image remote.
 	image := plan.Image.ValueString()
-	imageRemote := remote
 	imageParts := strings.SplitN(image, ":", 2)
 	if len(imageParts) == 2 {
 		imageRemote = imageParts[0]
 		image = imageParts[1]
 	}
 
-	var imageServer lxd.ImageServer
 	if imageRemote == "" {
 		// Use the instance server as an image server if image remote is empty.
 		imageServer = server


### PR DESCRIPTION
This is follow up on https://github.com/terraform-lxd/terraform-provider-lxd/pull/490.
If instance remote was set, the image's remote was not empty causing the image to be searched in default project.

This PR just ensures that the image remote is left empty if it is not explicitly set by the user. 

Reproducer:
```hcl
resource "lxd_project" "proj" {
  name = "proj"
  config = {
    "features.images"   = true
    "features.profiles" = false
  }
}

resource "lxd_cached_image" "alpine" {
    source_remote = "images"
    source_image  = "alpine/3.18"
    project       = lxd_project.proj.name
}

resource "lxd_instance" "c1" {
    name    = "c1"
    image   = lxd_cached_image.alpine.fingerprint
    project = lxd_project.proj.name
    remote  = "local" # <--
    running = false
}
```