### PR TITLE
Allow managing default profiles in non-default projects

### DIFF
--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -41,6 +41,25 @@ resource "lxd_instance" "test1" {
 }
 ```
 
+Default profiles in LXD are special because they are created automatically and cannot be removed.
+The provider will attempt to update these profiles and, if successful, import them into the Terraform state.
+```hcl
+resource "lxd_project" "myproject" {
+  name = "myproject"
+  config = {
+    "features.profiles": true
+  }
+}
+
+resource "lxd_profile" "default" {
+  name        = "default"
+  project     = lxd_project.myproject.name
+  description = "Modified default profile description"
+}
+```
+
+~> **Note:** Default profiles can be managed only in non-default projects that have `features.profiles` set to `true`.
+
 ## Argument Reference
 
 * `name` - **Required** - Name of the profile.


### PR DESCRIPTION
Allow managing default profile in non-default projects. When `default` profile is created, instead of trying to create it, fetch the existing, update it, and inject it into the Terraform state.

Default profile cannot be managed if it is located in project `default` or if the project has `features.profiles` set to `false` (disabled).