### PR TITLE
Remove LXD version check during password auth

### DIFF
--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -261,15 +261,6 @@ func (p *LxdProviderConfig) createLxdServerClient(remote LxdProviderRemoteConfig
 					req.Password = remote.Token
 				}
 			} else if remote.Password != "" {
-				ok, err := utils.CheckVersion(server.Environment.ServerVersion, ">= 6.0.0")
-				if err != nil {
-					return err
-				}
-
-				if !ok {
-					return fmt.Errorf("LXD server does not support password authentication from version 6.0 onwards")
-				}
-
 				req.Password = remote.Password
 			}
 


### PR DESCRIPTION
LXD version check is not possible for untrusted client, therefore remove the check. LXD will report back the error that server does not support the password auth.

Fixes #515