### PR TITLE
tests: Add cluster tests

### DIFF
--- a/.github/actions/cluster/action.yml
+++ b/.github/actions/cluster/action.yml
@@ -1,0 +1,53 @@
+name: LXD Cluster Setup
+description: Sets up the LXD cluster for testing.
+
+inputs:
+  cluster-name:
+    description: |
+      The name of the cluster. Used as a prefix for cluster member
+      instances and as a name of the remote on a local LXD client.
+    default: cls
+  cluster-size:
+    description: The size of the cluster.
+    default: 3
+  instance-type:
+    description: The instance type of the cluster member.
+    default: 'container'
+    options:
+      - container
+      - virtual-machine
+  lxd-version:
+    description: The version of LXD to install on each cluster member.
+    default: latest/edge
+
+runs:
+  using: composite
+  steps:
+      # Remove Docker to avoid conflicts with LXD networks.
+    - name: Remove Docker
+      uses: canonical/lxd/.github/actions/disable-docker@main
+
+    - name: Remove existing snaps
+      shell: bash
+      run: |
+        for s in $(snap list | awk '!/^(Name|core|snapd)/ {print $1}'); do
+          sudo snap remove --purge "${s}" || true
+        done
+
+    - name: Setup LXD
+      shell: bash
+      run: |
+        sudo snap install lxd --channel=latest/stable
+        sudo lxd waitready --timeout 60
+        sudo lxd init --auto --network-port=8443 --network-address=localhost
+        sudo chmod 777 /var/snap/lxd/common/lxd/unix.socket
+
+    - run: ./lxd-cluster.sh deploy
+      working-directory: ${{ github.action_path }}
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
+        CLUSTER_SIZE: ${{ inputs.cluster-size }}
+        INSTANCE_TYPE: ${{ inputs.instance-type }}
+        INSTANCE_IMAGE: ubuntu:24.04
+        VERSION_LXD: ${{ inputs.lxd-version }}

--- a/.github/actions/cluster/lxd-cluster.sh
+++ b/.github/actions/cluster/lxd-cluster.sh
@@ -1,0 +1,332 @@
+#!/bin/bash
+
+set -e
+
+#================================================
+# Variables
+#================================================
+
+# Cluster name and size.
+CLUSTER_NAME="${CLUSTER_NAME:-cls}"
+CLUSTER_SIZE="${CLUSTER_SIZE:-3}"
+
+# Image to use for cluster instances.
+INSTANCE_IMAGE="${INSTANCE_IMAGE:-ubuntu:24.04}"
+
+# Type of cluster instances (container or virtual-machine).
+INSTANCE_TYPE="${INSTANCE_TYPE:-container}"
+
+# Version of LXD to install.
+VERSION_LXD="${VERSION_LXD:-latest/edge}"
+
+# MinIO configuration.
+MINIO_ENABLED="${MINIO_ENABLED:-true}"
+MINIO_INSTALL_DIR="${MINIO_PATH:-/usr/local/bin}"
+
+# Other.
+INSTANCE="${CLUSTER_NAME}"
+LEADER="${CLUSTER_NAME}-1"
+STORAGE_POOL="${CLUSTER_NAME}-pool"
+STORAGE_DRIVER="dir"
+NETWORK_NAME="${CLUSTER_NAME}br0"
+
+#================================================
+# Utils
+#================================================
+
+# waitInstance waits for the VM to become ready.
+waitInstance() {
+        local instance="$1"
+        local timeout="${2:-60}"
+
+        if [ "${instance}" = "" ]; then
+                echo "Error: waitInstance: missing argument: instance name"
+                return 1
+        fi
+
+        echo "Waiting instance ${instance} to become ready ..."
+        for j in $(seq 1 "${timeout}"); do
+                local procCount=$(lxc info "${instance}" | awk '/Processes:/ {print $2}')
+                if [ "${procCount:-0}" -gt 0 ]; then
+                        echo "Instance ${instance} ready after ${j} seconds."
+                        break
+                fi
+
+                if [ "${j}" -ge "${timeout}" ]; then
+                        echo "Error: Instance ${instance} still not ready after ${timeout} seconds!"
+                        return 1
+                fi
+
+                sleep 1
+        done
+}
+
+# instanceIPv4 returns the IPv4 address of the instance with the given name.
+instanceIPv4() {
+        instance="$1"
+
+        # Try for enp5s0 (VM) and eth0 (container) interfaces.
+        for inf in enp5s0 eth0; do
+                ipv4=$(lxc ls "${instance}" -f csv -c 4 | grep -oP "(\d{1,3}\.){3}\d{1,3}(?= \(${inf}\))" || true)
+                if [ "${ipv4}" != "" ]; then
+                        echo "${ipv4}"
+                        return
+                fi
+        done
+
+        echo "Error: Failed to obtain IPv4 address of instance ${instance}"
+        return 1
+}
+
+
+#========================
+# Cluster setup
+#========================
+
+# deploy deploys instances required for a LXD cluster.
+deploy() {
+        # Create dedicated network.
+        echo "Creating network ${NETWORK_NAME} ..."
+        exists=$(lxc network list --format csv | awk -F, '{print $1}' | grep "${NETWORK_NAME}" || true)
+        if [ ! "${exists}" ]; then
+                lxc network create "${NETWORK_NAME}"
+        fi
+
+        # Create storage pool.
+        echo "Creating storage pool ${STORAGE_POOL} ..."
+        exists=$(lxc storage list --format csv | awk -F, '{print $1}' | grep "${STORAGE_POOL}" || true)
+        if [ ! "${exists}" ]; then
+                lxc storage create "${STORAGE_POOL}" zfs
+        fi
+
+        # Setup cluster VMs.
+        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                instance="${INSTANCE}-${i}"
+
+                state=$(lxc list --format csv --columns s "${instance}")
+                case "${state}" in
+                "RUNNING")
+                        echo "Instance ${instance} already running."
+                        continue
+                        ;;
+                "STOPPED")
+                        echo "Starting instance ${instance}..."
+                        lxc start "${instance}"
+                        continue
+                        ;;
+                esac
+
+                args=""
+                if [ "${INSTANCE_TYPE}" = "virtual-machine" ]; then
+                        args="--vm"
+                else
+                        args="-c security.nesting=true"
+                fi
+
+                echo "Creating instance ${instance} ..."
+
+                lxc launch "${INSTANCE_IMAGE}" "${instance}" \
+                        --storage "${STORAGE_POOL}" \
+                        --network "${NETWORK_NAME}" \
+                        -c limits.cpu=4 \
+                        -c limits.memory=4GiB \
+                        $args
+        done
+
+        # Wait for instances to become ready.
+        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                instance="${INSTANCE}-${i}"
+                waitInstance "${instance}"
+                lxc exec "${instance}" -- systemctl is-system-running --wait
+        done
+
+        # Install LXD on VMs.
+        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                instance="${INSTANCE}-${i}"
+
+                echo "Preparing instance ${instance} ..."
+
+                # Install snap daemon.
+                lxc exec "${instance}" --env=DEBIAN_FRONTEND=noninteractive -- apt-get -qq -y install snapd
+
+                # Install LXD snap.
+                lxc exec "${instance}" -- snap install lxd --channel "${VERSION_LXD}" || lxc exec "${instance}" -- snap refresh lxd --channel "${VERSION_LXD}"
+        done
+
+        echo "Cluster instances created."
+        lxc list
+}
+
+# configure_lxd configures LXD cluster.
+configure_lxd() {
+        echo "Creating LXD cluster ..."
+
+        # Create LXD cluster.
+        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                instance="${INSTANCE}-${i}"
+
+                isClustered=$(lxc exec "${instance}" -- lxc cluster list 2> /dev/null || true)
+                if [ "${isClustered}" ]; then
+                        continue
+                fi
+
+                # Get IPv4 of the instance.
+                ipv4=$(instanceIPv4 "${instance}")
+
+                # On the leader instance, just enable clustering and continue.
+                if [ "${instance}" = "${LEADER}" ]; then
+                        lxc exec "${instance}" -- lxc config set core.https_address "${ipv4}"
+                        lxc exec "${instance}" -- lxc cluster enable "${instance}"
+                        continue
+                fi
+
+                # Create and extract token for a new cluster member.
+                token=$(lxc exec "${LEADER}" -- lxc cluster add -q "${instance}")
+                if [ "${token}" = "" ]; then
+                        echo "Error: Failed retrieveing join token for instance ${instance}"
+                        exit 1
+                fi
+
+                # Apply the cluster member configuration.
+                lxc exec "${instance}" -- lxd init --preseed << EOF
+cluster:
+  enabled: true
+  server_address: ${ipv4}
+  cluster_token: ${token}
+EOF
+        done
+
+        # Install and configure MinIO on each cluster member.
+        if [ "${MINIO_ENABLED}" == "true" ]; then
+                curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/minio --output "/tmp/minio"
+                curl -sSfL https://dl.min.io/client/mc/release/linux-amd64/mc --output "/tmp/mc"
+
+                chmod +x "/tmp/minio"
+                chmod +x "/tmp/mc"
+
+                for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                        instance="${INSTANCE}-${i}"
+                        hasBucketSupport=$(lxc exec "${instance}" -- lxc info | grep -e "- storage_buckets" || true)
+
+                        # Install MinIO if enabled.
+                        if [ "${hasBucketSupport}" != "" ]; then
+                                echo "Installing MinIO server and client on instance ${instance} ..."
+
+                                lxc exec "${instance}" -- mkdir -p "${MINIO_INSTALL_DIR}"
+
+                                # Upload MinIO sever and client binaries.
+                                lxc file push /tmp/minio "${instance}/${MINIO_INSTALL_DIR}/minio"
+                                lxc file push /tmp/mc "${instance}${MINIO_INSTALL_DIR}/mc"
+
+                                # Configure MinIO.
+                                lxc exec "${instance}" -- snap set lxd minio.path="${MINIO_INSTALL_DIR}"
+                                lxc exec "${instance}" -- snap restart lxd
+                                lxc exec "${instance}" -- lxd waitready --timeout 30
+                                lxc exec "${instance}" -- lxc config set core.storage_buckets_address ":8555" || true
+                        fi
+                done
+
+                rm /tmp/minio /tmp/mc
+        fi
+
+        # Create default storage pool.
+        exists=$(lxc exec "${LEADER}" -- lxc storage list | grep "default" || true)
+        if [ ! "${exists}" ]; then
+                for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                        instance="${INSTANCE}-${i}"
+                        lxc exec "${LEADER}" -- lxc storage create default "${STORAGE_DRIVER}" --target "${instance}"
+                done
+
+                lxc exec "${LEADER}" -- lxc storage create default "${STORAGE_DRIVER}"
+                lxc exec "${LEADER}" -- lxc profile device add default root disk pool=default path=/
+
+                # Resize default storage.
+                if [ "${STORAGE_DRIVER}" != "dir" ]; then
+                        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                                instance="${INSTANCE}-${i}"
+                                lxc exec "${LEADER}" -- lxc storage set default size 3GiB --target "${instance}"
+                        done
+                fi
+        fi
+
+        # Create default managed network (lxdbr0).
+        exists=$(lxc exec "${LEADER}" -- lxc network list | grep "lxdbr0" || true)
+        if [ ! "${exists}" ]; then
+                for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                        instance="${INSTANCE}-${i}"
+                        lxc exec "${LEADER}" -- lxc network create lxdbr0 --target "${instance}"
+                done
+
+                lxc exec "${LEADER}" -- lxc network create lxdbr0
+                lxc exec "${LEADER}" -- lxc profile device add default eth0 nic nictype=bridged parent=lxdbr0
+        fi
+
+        # Configure new cluster remote.
+        token=$(lxc exec "${LEADER}" -- lxc config trust add --name host --quiet)
+        ipv4=$(instanceIPv4 "${LEADER}")
+
+        lxc remote rm "${CLUSTER_NAME}" 2>/dev/null || true
+        lxc remote add "${CLUSTER_NAME}" "${ipv4}" --token "${token}"
+        lxc remote switch "${CLUSTER_NAME}"
+
+        # Show final cluster.
+        lxc cluster list "${CLUSTER_NAME}:"
+}
+
+
+#================================================
+# Cleanup
+#================================================
+
+# cleanup removes the deployed resources.
+#
+cleanup() {
+        # Remove VMs.
+        echo "Removing instances ..."
+        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                instance="${INSTANCE}-${i}"
+                lxc delete "${instance}" --force || true
+        done
+
+        # Remove storage pool.
+        echo "Removing storage pool ${STORAGE_POOL} ..."
+        lxc storage delete "${STORAGE_POOL}" || true
+
+        # Remove network.
+        echo "Removing network ${NETWORK_NAME} ..."
+        lxc network delete "${NETWORK_NAME}"  || true
+
+        # Remove remote.
+        lxc remote switch local
+        lxc remote rm "${CLUSTER_NAME}" 2>/dev/null || true
+}
+
+#================================================
+# Script
+#================================================
+
+action="${1:-}"
+case "${action}" in
+        deploy)
+                echo "==> RUN: Deploy"
+
+                deploy
+                configure_lxd
+
+                echo ""
+                echo "==> DONE: LXD cluster created"
+                ;;
+        cleanup)
+                echo "==> RUN: Cleanup"
+                cleanup
+
+                echo ""
+                echo "==> Done: LXD cluster removed"
+                ;;
+        *)
+                echo "Unkown action: ${action}"
+                echo "Valid actions are: [deploy, cleanup]"
+                echo "Run: $0 <action>"
+                exit 1
+                ;;
+esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,15 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  TF_ACC: "1"
+  GO111MODULE: "on"
+  LXD_GENERATE_CLIENT_CERTS: "true"
+  LXD_ACCEPT_SERVER_CERTIFICATE: "true"
+
 name: Test
 jobs:
-  acceptance-tests:
+  acceptance-standalone:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -27,12 +33,6 @@ jobs:
           - 5.21/edge
           - latest/stable
           - latest/edge
-
-    env:
-      TF_ACC: "1"
-      GO111MODULE: "on"
-      LXD_GENERATE_CLIENT_CERTS: "true"
-      LXD_ACCEPT_SERVER_CERTIFICATE: "true"
 
     steps:
       - uses: actions/checkout@v4
@@ -90,6 +90,39 @@ jobs:
             external_ids:ovn-remote=unix:/var/run/ovn/ovnsb_db.sock \
             external_ids:ovn-encap-type=geneve \
             external_ids:ovn-encap-ip=127.0.0.1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Run acceptance tests
+        run: make test
+
+  acceptance-cluster:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        channel:
+          - 5.0/edge
+          - 5.21/edge
+          - latest/candidate
+          # - latest/edge
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Setup LXD cluster
+        uses: ./.github/actions/cluster
+        with:
+          cluster-name: acctest
+          lxd-version: ${{ matrix.channel }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/internal/acctest/checks.go
+++ b/internal/acctest/checks.go
@@ -103,6 +103,20 @@ func PreCheckClustering(t *testing.T) {
 	}
 }
 
+// PreCheckStandalone skips the test if LXD server is not running
+// in standalone mode (or in other words if LXD is clustered).
+func PreCheckStandalone(t *testing.T) {
+	p := testProvider()
+	server, err := p.InstanceServer("", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if server.IsClustered() {
+		t.Skipf("Test %q skipped. LXD server is not running in standalone mode.", t.Name())
+	}
+}
+
 // PreCheckRoot skips the test if the user cannot escalate privileges without a password.
 // Root is required for certain tests, such as creating a loopback device for storage.
 // This ensures tests do not stop midway asking for password.

--- a/internal/image/resource_cached_image_test.go
+++ b/internal/image/resource_cached_image_test.go
@@ -215,7 +215,10 @@ func TestAccCachedImage_instanceFromImageFingerprint(t *testing.T) {
 	instanceName := acctest.GenerateName(2, "")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // The remote "local" does not point to clustered LXD.
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -568,7 +568,10 @@ func TestAccInstance_fileUploadVirtualMachine(t *testing.T) {
 	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckVirtualization(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -1159,26 +1159,24 @@ func TestAccInstance_accessInterfaceFromProfile(t *testing.T) {
 }
 
 func TestAccInstance_target(t *testing.T) {
+	targets := acctest.PreCheckClustering(t, 1)
 	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckClustering(t)
-		},
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstance_target(instanceName, "node-2"),
+				Config: testAccInstance_target(instanceName, targets[0]),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", fmt.Sprintf("%s-1", instanceName)),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "image", acctest.TestImage),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "target", "node-2"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "target", targets[0]),
 					resource.TestCheckResourceAttr("lxd_instance.instance2", "name", fmt.Sprintf("%s-2", instanceName)),
 					resource.TestCheckResourceAttr("lxd_instance.instance2", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance2", "image", acctest.TestImage),
-					resource.TestCheckResourceAttr("lxd_instance.instance2", "target", "node-2"),
+					resource.TestCheckResourceAttr("lxd_instance.instance2", "target", targets[0]),
 				),
 			},
 		},

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -419,7 +419,10 @@ func TestAccInstance_noProfile(t *testing.T) {
 	name := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Due to standalone storage pool creation.
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -1084,7 +1087,10 @@ func TestAccInstance_accessInterface(t *testing.T) {
 	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Due to standalone network creation.
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -1118,7 +1124,10 @@ func TestAccInstance_accessInterfaceFromProfile(t *testing.T) {
 	networkName := acctest.GenerateName(1, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Due to standalone network creation.
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/network/resource_network_forward_test.go
+++ b/internal/network/resource_network_forward_test.go
@@ -12,7 +12,10 @@ func TestAccNetworkForward_basic(t *testing.T) {
 	networkName := acctest.GenerateName(1, "")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Due to standalone network creation.
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -47,7 +50,10 @@ func TestAccNetworkForward_Ports(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Due to standalone network creation.
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/network/resource_network_lb_test.go
+++ b/internal/network/resource_network_lb_test.go
@@ -14,6 +14,7 @@ func TestAccNetworkLB_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -45,6 +46,7 @@ func TestAccNetworkLB_withConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -85,6 +87,7 @@ func TestAccNetworkLB_withBackend(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -131,6 +134,7 @@ func TestAccNetworkLB_withBackend_noDescriptions(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,

--- a/internal/network/resource_network_peer_test.go
+++ b/internal/network/resource_network_peer_test.go
@@ -13,7 +13,10 @@ func TestAccNetworkPeer_basic(t *testing.T) {
 	dstNetwork := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Due to standalone network creation.
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +48,10 @@ func TestAccNetworkPeer_import(t *testing.T) {
 	dstNetwork := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Due to standalone network creation.
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -12,7 +12,10 @@ func TestAccNetwork_basic(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -33,7 +36,10 @@ func TestAccNetwork_description(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -55,7 +61,10 @@ func TestAccNetwork_nullable(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -78,7 +87,10 @@ func TestAccNetwork_attach(t *testing.T) {
 	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -109,7 +121,10 @@ func TestAccNetwork_updateConfig(t *testing.T) {
 	instanceName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -146,7 +161,10 @@ func TestAccNetwork_typeMacvlan(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -194,7 +212,10 @@ func TestAccNetwork_project(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -214,7 +235,10 @@ func TestAccNetwork_importBasic(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -236,7 +260,10 @@ func TestAccNetwork_importDesc(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -259,7 +286,10 @@ func TestAccNetwork_importProject(t *testing.T) {
 	projectName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -51,6 +51,7 @@ MDEtMDEtMDFUMDA6MDA6MDBaIgp9Cg==`
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Cluster is not accessible on localhost.
 			acctest.PreCheckLocalServerHTTPS(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -98,6 +99,7 @@ func TestAccProvider_trustPassword(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Cluster is not accessible on localhost.
 			acctest.PreCheckLocalServerHTTPS(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -167,6 +169,7 @@ func TestAccProvider_acceptRemoteCertificate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t) // Cluster is not accessible on localhost.
 			acctest.PreCheckLocalServerHTTPS(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,

--- a/internal/storage/resource_storage_bucket_key_test.go
+++ b/internal/storage/resource_storage_bucket_key_test.go
@@ -18,6 +18,7 @@ func TestAccStorageBucketKey_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "storage_buckets")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -111,6 +112,7 @@ func TestAccStorageBucketKey_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "storage_buckets")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,

--- a/internal/storage/resource_storage_bucket_test.go
+++ b/internal/storage/resource_storage_bucket_test.go
@@ -35,21 +35,22 @@ func TestAccStorageBucket_basic(t *testing.T) {
 }
 
 func TestAccStorageBucket_target(t *testing.T) {
+	targets := acctest.PreCheckClustering(t, 1)
 	bucketName := petname.Generate(2, "-")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckClustering(t)
 			acctest.PreCheckAPIExtensions(t, "storage_buckets")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStorageBucket_target(bucketName),
+				Config: testAccStorageBucket_target(bucketName, targets[0]),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_storage_bucket.bucket1", "name", bucketName),
 					resource.TestCheckResourceAttr("lxd_storage_bucket.bucket1", "pool", "default"),
+					resource.TestCheckResourceAttr("lxd_storage_bucket.bucket1", "target", targets[0]),
 				),
 			},
 		},
@@ -147,14 +148,14 @@ resource "lxd_storage_bucket" "bucket1" {
 	`, poolName, bucketName)
 }
 
-func testAccStorageBucket_target(bucketName string) string {
+func testAccStorageBucket_target(bucketName string, target string) string {
 	return fmt.Sprintf(`
 resource "lxd_storage_bucket" "bucket1" {
   name   = "%s"
   pool   = "default"
-  target = "node-2"
+  target = "%s"
 }
- 	`, bucketName)
+ 	`, bucketName, target)
 }
 
 func testAccStorageBucket_project(projectName string, bucketName string) string {

--- a/internal/storage/resource_storage_bucket_test.go
+++ b/internal/storage/resource_storage_bucket_test.go
@@ -16,6 +16,7 @@ func TestAccStorageBucket_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "storage_buckets")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -87,6 +88,7 @@ func TestAccStorageBucket_importBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "storage_buckets")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,

--- a/internal/storage/resource_storage_pool_test.go
+++ b/internal/storage/resource_storage_pool_test.go
@@ -18,7 +18,10 @@ func TestAccStoragePool_dir(t *testing.T) {
 	driverName := "dir"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +52,10 @@ func TestAccStoragePool_zfs(t *testing.T) {
 	driverName := "zfs"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -82,7 +88,10 @@ func TestAccStoragePool_lvm(t *testing.T) {
 	driverName := "lvm"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -116,7 +125,10 @@ func TestAccStoragePool_btrfs(t *testing.T) {
 	driverName := "btrfs"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -147,7 +159,10 @@ func TestAccStoragePool_config(t *testing.T) {
 	poolName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -195,7 +210,10 @@ func TestAccStoragePool_configSource(t *testing.T) {
 		t.Run(fmt.Sprintf("%s[%s]", t.Name(), poolDriver), func(t *testing.T) {
 			defer cleanup()
 			resource.Test(t, resource.TestCase{
-				PreCheck:                 func() { acctest.PreCheck(t) },
+				PreCheck: func() {
+					acctest.PreCheck(t)
+					acctest.PreCheckStandalone(t)
+				},
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Steps: []resource.TestStep{
 					{
@@ -223,7 +241,10 @@ func TestAccStoragePool_project(t *testing.T) {
 	driverName := "dir"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -275,7 +296,10 @@ func TestAccStoragePool_importBasic(t *testing.T) {
 	resourceName := "lxd_storage_pool.storage_pool1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -298,7 +322,10 @@ func TestAccStoragePool_importConfig(t *testing.T) {
 	resourceName := "lxd_storage_pool.storage_pool1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -322,7 +349,10 @@ func TestAccStoragePool_importProject(t *testing.T) {
 	resourceName := "lxd_storage_pool.storage_pool1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/storage/resource_storage_pool_test.go
+++ b/internal/storage/resource_storage_pool_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -263,27 +264,25 @@ func TestAccStoragePool_project(t *testing.T) {
 }
 
 func TestAccStoragePool_target(t *testing.T) {
+	targets := acctest.PreCheckClustering(t, 2)
 	poolName := acctest.GenerateName(2, "-")
 	driverName := "dir"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckClustering(t)
-		},
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStoragePool_target(poolName, driverName),
+				Config: testAccStoragePool_target(poolName, driverName, targets),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node1", "name", poolName),
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node1", "driver", driverName),
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node1", "target", "node-1"),
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node2", "name", poolName),
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node2", "driver", driverName),
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1_node2", "target", "node-2"),
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "name", poolName),
-					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "driver", driverName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool_node1", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool_node1", "driver", driverName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool_node1", "target", targets[0]),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool_node2", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool_node2", "driver", driverName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool_node2", "target", targets[1]),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool", "driver", driverName),
 				),
 			},
 		},
@@ -418,30 +417,28 @@ resource "lxd_storage_pool" "storage_pool1" {
 	`, project, name, driver)
 }
 
-func testAccStoragePool_target(name, driver string) string {
-	return fmt.Sprintf(`
-resource "lxd_storage_pool" "storage_pool1_node1" {
-  name   = "%[1]s"
-  driver = "%[2]s"
-  target = "node-1"
-}
+func testAccStoragePool_target(name string, driver string, targets []string) string {
+	var config string
+	var deps []string
 
-resource "lxd_storage_pool" "storage_pool1_node2" {
-  name   = "%[1]s"
-  driver = "%[2]s"
-  target = "node-2"
-}
+	for i, target := range targets {
+		deps = append(deps, "lxd_storage_pool.storage_pool_node"+strconv.Itoa(i+1))
+		config += fmt.Sprintf(`
+resource "lxd_storage_pool" "storage_pool_node%d" {
+  name   = "%s"
+  driver = "%s"
+  target = "%s"
+}`, i+1, name, driver, target)
+	}
 
-resource "lxd_storage_pool" "storage_pool1" {
-  depends_on = [
-    lxd_storage_pool.storage_pool1_node1,
-    lxd_storage_pool.storage_pool1_node2,
-  ]
+	config += fmt.Sprintf(`
+resource "lxd_storage_pool" "storage_pool" {
+  depends_on = [ %[3]s ]
+  name       = "%[1]s"
+  driver     = "%[2]s"
+}`, name, driver, strings.Join(deps, ", "))
 
-  name   = "%[1]s"
-  driver = "%[2]s"
-}
-	`, name, driver)
+	return config
 }
 
 // ensureSource ensures temporary storage pool source is created based on the provided

--- a/internal/storage/resource_storage_volume_copy_test.go
+++ b/internal/storage/resource_storage_volume_copy_test.go
@@ -14,7 +14,10 @@ func TestAccStorageVolumeCopy_basic(t *testing.T) {
 	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/storage/resource_storage_volume_test.go
+++ b/internal/storage/resource_storage_volume_test.go
@@ -13,7 +13,10 @@ func TestAccStorageVolume_basic(t *testing.T) {
 	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -37,7 +40,10 @@ func TestAccStorageVolume_instanceAttach(t *testing.T) {
 	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -109,7 +115,10 @@ func TestAccStorageVolume_contentType(t *testing.T) {
 	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -132,7 +141,10 @@ func TestAccStorageVolume_importBasic(t *testing.T) {
 	resourceName := "lxd_volume.volume1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -155,7 +167,10 @@ func TestAccStorageVolume_importProject(t *testing.T) {
 	resourceName := "lxd_volume.volume1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -177,7 +192,10 @@ func TestAccStorageVolume_inheritedStoragePoolKeys(t *testing.T) {
 	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/storage/resource_storage_volume_test.go
+++ b/internal/storage/resource_storage_volume_test.go
@@ -68,21 +68,19 @@ func TestAccStorageVolume_instanceAttach(t *testing.T) {
 }
 
 func TestAccStorageVolume_target(t *testing.T) {
+	targets := acctest.PreCheckClustering(t, 1)
 	volumeName := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckClustering(t)
-		},
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStorageVolume_target(volumeName),
+				Config: testAccStorageVolume_target(volumeName, targets[0]),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_volume.volume1", "name", volumeName),
 					resource.TestCheckResourceAttr("lxd_volume.volume1", "pool", "default"),
-					resource.TestCheckResourceAttr("lxd_volume.volume1", "target", "node-2"),
+					resource.TestCheckResourceAttr("lxd_volume.volume1", "target", targets[0]),
 				),
 			},
 		},
@@ -263,14 +261,14 @@ resource "lxd_instance" "instance1" {
 	`, poolName, volumeName, instanceName, acctest.TestImage)
 }
 
-func testAccStorageVolume_target(volumeName string) string {
+func testAccStorageVolume_target(volumeName string, target string) string {
 	return fmt.Sprintf(`
 resource "lxd_volume" "volume1" {
   name   = "%s"
   pool   = "default"
-  target = "node-2"
+  target = "%s"
 }
-	`, volumeName)
+	`, volumeName, target)
 }
 
 func testAccStorageVolume_project(projectName, volumeName string) string {


### PR DESCRIPTION
Add cluster tests. This PR adds an action that contains a script to setup test LXD cluster.

Some tests were added standalone prechecks, to avoid running them when LXD is clustered. For example when creating a local storage pool.