### PR TITLE
feat: allow creation of empty VMs

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -47,8 +47,8 @@ resource "lxd_instance" "instance2" {
 
 * `name` - **Required** - Name of the instance.
 
-* `image` - **Required** - Base image from which the instance will be created. Must
-  specify [an image accessible from the provider remote](https://documentation.ubuntu.com/lxd/en/latest/reference/remote_image_servers/).
+* `image` - **Optional** - Base image from which the instance will be created. **For containers** it must
+  specify [an image accessible from the provider remote](https://documentation.ubuntu.com/lxd/en/latest/reference/remote_image_servers/). If omitted, it is equivalent to the `--empty` CLI flag and creates an empty virtual machine.
 
 * `description` - *Optional* - Description of the instance.
 


### PR DESCRIPTION
Note: the `TestAccInstance_empty_vm` is skipped due to the LXD agent not
coming up (since there's no OS booted). Open for ideas on how to test
this efficiently. My only ideas have been PXE booting in a pre-existing
environment or attaching a custom ISO volume. Both of them are not
really portable.

fixes #561

Signed-off-by: Matthias Riegler <github@m4tbit.de>
