### PR TITLE
instance_file: Fix file removal and panic when file is not found

### DIFF
--- a/internal/instance/resource_instance_file.go
+++ b/internal/instance/resource_instance_file.go
@@ -263,9 +263,16 @@ func (r InstanceFileResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	// Fetch file
+	// Fetch an existing file.
 	_, file, err := server.GetInstanceFile(instanceName, targetPath)
 	if err != nil {
+		if errors.IsNotFoundError(err) {
+			// If file is not found, remove it from the Terraform state
+			// to ensure it is recreated.
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve file %q from instance %q", targetPath, instanceName), err.Error())
 		return
 	}

--- a/internal/instance/resource_instance_file.go
+++ b/internal/instance/resource_instance_file.go
@@ -267,6 +267,7 @@ func (r InstanceFileResource) Read(ctx context.Context, req resource.ReadRequest
 	_, file, err := server.GetInstanceFile(instanceName, targetPath)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve file %q from instance %q", targetPath, instanceName), err.Error())
+		return
 	}
 
 	state.Instance = types.StringValue(instanceName)

--- a/internal/instance/resource_instance_file.go
+++ b/internal/instance/resource_instance_file.go
@@ -324,20 +324,9 @@ func (r InstanceFileResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	file := common.InstanceFileModel{
-		Content:    state.Content,
-		SourcePath: state.SourcePath,
-		TargetPath: state.TargetPath,
-		UserID:     state.UserID,
-		GroupID:    state.GroupID,
-		Mode:       state.Mode,
-		CreateDirs: state.CreateDirs,
-		Append:     state.Append,
-	}
-
 	// Delete file.
-	err = common.InstanceFileUpload(server, instanceName, file)
-	if err != nil {
+	err = common.InstanceFileDelete(server, instanceName, state.TargetPath.ValueString())
+	if err != nil && !errors.IsNotFoundError(err) {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to delete file %q from instance %q", targetFile, instanceName), err.Error())
 		return
 	}

--- a/internal/instance/resource_instance_file.go
+++ b/internal/instance/resource_instance_file.go
@@ -256,6 +256,9 @@ func (r InstanceFileResource) Read(ctx context.Context, req resource.ReadRequest
 	instance, _, err := server.GetInstance(instanceName)
 	if err != nil {
 		if errors.IsNotFoundError(err) {
+			// If instance is not found, file cannot exist. Remove it
+			// from the state to ensure it is created on next apply.
+			resp.State.RemoveResource(ctx)
 			return
 		}
 


### PR DESCRIPTION
Reproducer for panic:

```hcl
resource "lxd_instance" "c1" {
    name    = "c1"
    image   = "images:alpine/edge"
    running = true
}

resource "lxd_instance_file" "file1" {
  instance           = lxd_instance.c1.name
  content            = "test"
  target_path        = "/foo/bar.txt"
  create_directories = true
}
```

```sh
terraform apply
lxc exec c1 -- rm /foo/bar.txt
terraform apply
```

Additionally, it fixes file removal, which was went unnoticed until now.

Fixes #565
Fixes #566