### PR TITLE
Fix leftover resources on error

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -671,11 +671,11 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	// Partially update state, to make terraform aware of
-	// an existing instance.
-	diags = resp.State.SetAttribute(ctx, path.Root("name"), instance.Name)
-	if diags.HasError() {
-		resp.Diagnostics.Append(diags...)
+	// Partially update state to make Terraform aware of the created resource.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), instance.Name)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), project)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/instance/resource_instance_snapshot.go
+++ b/internal/instance/resource_instance_snapshot.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -169,6 +170,15 @@ func (r InstanceSnapshotResource) Create(ctx context.Context, req resource.Creat
 
 	if serr != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to create snapshot %q for instance %q", snapshotName, instanceName), serr.Error())
+		return
+	}
+
+	// Partially update state to make Terraform aware of the created resource.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), snapshotName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("instance"), instanceName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), project)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -177,6 +177,14 @@ func (r NetworkResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Partially update state to make Terraform aware of the created resource.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), network.Name)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), project)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	diags = r.SyncState(ctx, &resp.State, server, plan)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/network/resource_network_lb.go
+++ b/internal/network/resource_network_lb.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -230,6 +231,15 @@ func (r LxdNetworkLBResource) Create(ctx context.Context, req resource.CreateReq
 	err = server.CreateNetworkLoadBalancer(networkName, lbReq)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to create network load balancer %q", lbName), err.Error())
+		return
+	}
+
+	// Partially update state to make Terraform aware of the created resource.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("network"), networkName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("listen_address"), listenAddr)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), project)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/network/resource_network_zone.go
+++ b/internal/network/resource_network_zone.go
@@ -141,6 +141,14 @@ func (r NetworkZoneResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	// Partially update state to make Terraform aware of the created resource.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), zoneName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), project)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Update Terraform state.
 	diags = r.SyncState(ctx, &resp.State, server, plan)
 	resp.Diagnostics.Append(diags...)

--- a/internal/profile/resource_profile.go
+++ b/internal/profile/resource_profile.go
@@ -218,6 +218,14 @@ func (r ProfileResource) Create(ctx context.Context, req resource.CreateRequest,
 			resp.Diagnostics.AddError(fmt.Sprintf("Failed to create profile %q", profile.Name), err.Error())
 			return
 		}
+
+		// Partially update state to make Terraform aware of the created resource.
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), profile.Name)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), project)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 
 	// Update Terraform state.

--- a/internal/project/resource_project.go
+++ b/internal/project/resource_project.go
@@ -132,6 +132,13 @@ func (r ProjectResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Partially update state to make Terraform aware of the created resource.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), projectName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Update Terraform state.
 	diags = r.SyncState(ctx, &resp.State, server, plan)
 	resp.Diagnostics.Append(diags...)

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -183,6 +183,14 @@ func (r StoragePoolResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	// Partially update state to make Terraform aware of the created resource.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), pool.Name)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), project)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Update Terraform state.
 	diags = r.SyncState(ctx, &resp.State, server, plan)
 	resp.Diagnostics.Append(diags...)

--- a/internal/storage/resource_storage_volume.go
+++ b/internal/storage/resource_storage_volume.go
@@ -201,6 +201,15 @@ func (r StorageVolumeResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	// Partially update state to make Terraform aware of the created resource.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), volName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("pool"), poolName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), project)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("remote"), remote)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Update Terraform state.
 	diags = r.SyncState(ctx, &resp.State, server, plan)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
This PR ensures partial state is tracked for majority of resources. This means when a resource is created, we immediately include all the necessary information to uniquely identify the resource into Terraform state. If an error occurs, resource is marked as `tainted` and will be forced replaced on next apply.

Previously, we included partial state only for instances. The state included only instance name, which caused the project and remote to be incorrectly tracked. This resulted in leftover resources, as the provider does not error out if the resource is not found - the tainted resource was only found if it was in default project and default remote.