### PR TITLE
Fix segfault when taking instance snapshot for an instance doesn't exist

### DIFF
--- a/internal/instance/resource_instance_snapshot.go
+++ b/internal/instance/resource_instance_snapshot.go
@@ -143,10 +143,10 @@ func (r InstanceSnapshotResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	var serr error
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		op, err := server.CreateInstanceSnapshot(instanceName, snapshotReq)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Failed to create snapshot %q for instance %q", snapshotName, instanceName), serr.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("Failed to create snapshot %q for instance %q", snapshotName, instanceName), err.Error())
 			return
 		}
 

--- a/internal/instance/resource_instance_snapshot_test.go
+++ b/internal/instance/resource_instance_snapshot_test.go
@@ -2,6 +2,7 @@ package instance_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -116,6 +117,22 @@ func TestAccInstanceSnapshot_project(t *testing.T) {
 	})
 }
 
+func TestAccInstanceSnapshot_missingInstance(t *testing.T) {
+	instanceName := acctest.GenerateName(2, "-")
+	snapshotName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccInstanceSnapshot_missingInstance(instanceName, snapshotName),
+				ExpectError: regexp.MustCompile("Instance not\nfound"),
+			},
+		},
+	})
+}
+
 func testAccInstanceSnapshot_basic(cName, sName string, stateful bool) string {
 	return fmt.Sprintf(`
 resource "lxd_instance" "instance1" {
@@ -190,4 +207,13 @@ resource "lxd_snapshot" "snapshot1" {
   project  = lxd_project.project1.name
 }
 	`, project, instance, acctest.TestImage, snapshot)
+}
+
+func testAccInstanceSnapshot_missingInstance(cName, sName string) string {
+	return fmt.Sprintf(`
+resource "lxd_snapshot" "snapshot1" {
+  instance = "%s"
+  name     = "%s"
+}
+	`, cName, sName)
 }

--- a/internal/instance/resource_instance_snapshot_test.go
+++ b/internal/instance/resource_instance_snapshot_test.go
@@ -133,7 +133,7 @@ func TestAccInstanceSnapshot_missingInstance(t *testing.T) {
 	})
 }
 
-func testAccInstanceSnapshot_basic(cName, sName string, stateful bool) string {
+func testAccInstanceSnapshot_basic(instanceName, snapshotName string, stateful bool) string {
 	return fmt.Sprintf(`
 resource "lxd_instance" "instance1" {
   name  = "%s"
@@ -145,10 +145,10 @@ resource "lxd_snapshot" "snapshot1" {
   name     = "%s"
   stateful = "%v"
 }
-	`, cName, acctest.TestImage, sName, stateful)
+	`, instanceName, acctest.TestImage, snapshotName, stateful)
 }
 
-func testAccInstanceSnapshot_multiple1(cName, sName string) string {
+func testAccInstanceSnapshot_multiple1(instanceName, snapshotName string) string {
 	return fmt.Sprintf(`
 resource "lxd_instance" "instance1" {
   name  = "%s"
@@ -160,10 +160,10 @@ resource "lxd_snapshot" "snapshot1" {
   instance = lxd_instance.instance1.name
   stateful = false
 }
-	`, cName, acctest.TestImage, sName)
+	`, instanceName, acctest.TestImage, snapshotName)
 }
 
-func testAccInstanceSnapshot_multiple2(cName, sName1, sName2 string) string {
+func testAccInstanceSnapshot_multiple2(instanceName, snapshotName1, snapshotName2 string) string {
 	return fmt.Sprintf(`
 resource "lxd_instance" "instance1" {
   name = "%s"
@@ -181,7 +181,7 @@ resource "lxd_snapshot" "snapshot2" {
   instance = lxd_instance.instance1.name
   stateful = "false"
 }
-	`, cName, acctest.TestImage, sName1, sName2)
+	`, instanceName, acctest.TestImage, snapshotName1, snapshotName2)
 }
 func testAccInstanceSnapshot_project(project, instance, snapshot string) string {
 	return fmt.Sprintf(`
@@ -209,11 +209,11 @@ resource "lxd_snapshot" "snapshot1" {
 	`, project, instance, acctest.TestImage, snapshot)
 }
 
-func testAccInstanceSnapshot_missingInstance(cName, sName string) string {
+func testAccInstanceSnapshot_missingInstance(instanceName, snapshotName string) string {
 	return fmt.Sprintf(`
 resource "lxd_snapshot" "snapshot1" {
   instance = "%s"
   name     = "%s"
 }
-	`, cName, sName)
+	`, instanceName, snapshotName)
 }

--- a/internal/instance/resource_instance_snapshot_test.go
+++ b/internal/instance/resource_instance_snapshot_test.go
@@ -127,7 +127,7 @@ func TestAccInstanceSnapshot_missingInstance(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccInstanceSnapshot_missingInstance(instanceName, snapshotName),
-				ExpectError: regexp.MustCompile("Instance not\nfound"),
+				ExpectError: regexp.MustCompile("Instance not[ \n]found"),
 			},
 		},
 	})


### PR DESCRIPTION
This PR addresses https://github.com/terraform-lxd/terraform-provider-lxd/issues/569 which fixes the segfault when taking instance snapshot for an instance doesn't exist. It also implements a unit test so that we can see expected behavior