### PR TITLE
datasource: LXD info

### DIFF
--- a/docs/data-sources/info.md
+++ b/docs/data-sources/info.md
@@ -1,0 +1,23 @@
+# lxd_info
+
+Provides general information about LXD remote.
+
+## Example Usage
+
+```hcl
+data "lxd_info" "local" {
+  remote = "local"
+}
+```
+
+## Argument Reference
+
+* `remote` - *Optional* - The remote to inspect. If not provided, the provider's default remote is used.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `api_extensions` - List of API extensions supported by the LXD server.
+
+* `cluster_members` - Map of cluster members, which is empty if LXD is not clustered. The map key represents a cluster member name.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/profile"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/project"
 	provider_config "github.com/terraform-lxd/terraform-provider-lxd/internal/provider-config"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/server"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/storage"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/truststore"
 )
@@ -283,6 +284,7 @@ func (p *LxdProvider) DataSources(_ context.Context) []func() datasource.DataSou
 		network.NewNetworkDataSource,
 		profile.NewProfileDataSource,
 		project.NewProjectDataSource,
+		server.NewInfoDataSource,
 		storage.NewStoragePoolDataSource,
 	}
 }

--- a/internal/server/datasource_lxd_info.go
+++ b/internal/server/datasource_lxd_info.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/errors"
+	provider_config "github.com/terraform-lxd/terraform-provider-lxd/internal/provider-config"
+)
+
+type InfoModel struct {
+	Remote        types.String `tfsdk:"remote"`
+	APIExtensions types.List   `tfsdk:"api_extensions"`
+	Members       types.Map    `tfsdk:"cluster_members"`
+}
+
+type ClusterMemberModel struct {
+	URL    types.String `tfsdk:"url"`
+	Status types.String `tfsdk:"status"`
+}
+
+func NewInfoDataSource() datasource.DataSource {
+	return &InfoDataSource{}
+}
+
+type InfoDataSource struct {
+	provider *provider_config.LxdProviderConfig
+}
+
+func (d *InfoDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_info", req.ProviderTypeName)
+}
+
+func (d *InfoDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"remote": schema.StringAttribute{
+				Optional: true,
+			},
+
+			"api_extensions": schema.ListAttribute{
+				Description: "List of API extensions supported by the LXD server",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+
+			"cluster_members": schema.MapNestedAttribute{
+				Computed:    true,
+				Description: "Map of cluster members, which is empty if LXD is not clustered. The map key represents a cluster member name.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"url": schema.StringAttribute{
+							Description: "Cluster member URL",
+							Computed:    true,
+						},
+
+						"status": schema.StringAttribute{
+							Description: "Cluster member status",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *InfoDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.LxdProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+		return
+	}
+
+	d.provider = provider
+}
+
+func (d *InfoDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var diags diag.Diagnostics
+	var config InfoModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := d.provider.SelectRemote(config.Remote.ValueString())
+	server, err := d.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	apiServer, _, err := server.GetServer()
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve the API server from remote %q", remote), err.Error())
+		return
+	}
+
+	var clusterMembers map[string]ClusterMemberModel
+
+	if server.IsClustered() {
+		members, err := server.GetClusterMembers()
+		if err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve cluster members from remote %q", remote), err.Error())
+			return
+		}
+
+		clusterMembers = make(map[string]ClusterMemberModel, len(members))
+		for _, member := range members {
+			clusterMembers[member.ServerName] = ClusterMemberModel{
+				URL:    types.StringValue(member.URL),
+				Status: types.StringValue(member.Status),
+			}
+		}
+	}
+
+	config.Remote = types.StringValue(remote)
+
+	config.APIExtensions, diags = types.ListValueFrom(ctx, types.StringType, apiServer.APIExtensions)
+	resp.Diagnostics.Append(diags...)
+
+	config.Members, diags = ToClusterMemberMapType(ctx, clusterMembers)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.Set(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+}
+
+// ToClusterMemberMapType converts map[string]ClusterMemberModel into types.Map.
+func ToClusterMemberMapType(ctx context.Context, members map[string]ClusterMemberModel) (types.Map, diag.Diagnostics) {
+	objType := types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"url":    types.StringType,
+			"status": types.StringType,
+		},
+	}
+
+	if members == nil {
+		members = map[string]ClusterMemberModel{}
+	}
+
+	return types.MapValueFrom(ctx, objType, members)
+}

--- a/internal/server/datasource_lxd_info_test.go
+++ b/internal/server/datasource_lxd_info_test.go
@@ -1,0 +1,50 @@
+package server_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
+)
+
+func TestAccInfo_standalone(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfo(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.lxd_info.self", "remote"),
+					resource.TestCheckResourceAttr("data.lxd_info.self", "cluster_members.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccInfo_cluster(t *testing.T) {
+	members := acctest.PreCheckClustering(t, 1)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfo(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.lxd_info.self", "remote"),
+					resource.TestCheckResourceAttr("data.lxd_info.self", "cluster_members.%", strconv.Itoa(len(members))),
+				),
+			},
+		},
+	})
+}
+
+func testAccInfo() string {
+	return `data "lxd_info" "self" {}`
+}


### PR DESCRIPTION
Adds `lxd_info` datasource. It retrieves information about LXD from a given remote. Currently it reports only cluster members (if LXD is clustered) and supported API extensions. 