### PR TITLE
Add instance device resource

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -364,3 +364,7 @@ import {
   state and treated as computed values.
     - `image.*`
     - `volatile.*`
+
+* Terraform LXD provider sets user.managed-by key to all managed instance devices.
+  Removing that key from a device manually, would result in Terraform removing it on next apply.
+

--- a/docs/resources/instance_device.md
+++ b/docs/resources/instance_device.md
@@ -1,0 +1,87 @@
+# lxd_instance_device
+
+Manages a single device in an LXD instance. Provides an alternative way to attach
+and manage a device.
+
+This resource is useful for managing devices on a LXD instance in a cluster.
+For example, it allows attaching volumes to an instance with initially unknown
+location in the cluster.
+
+~> **Warning:** This is an experimental feature of Terraform LXD Provider and it may
+   change in the future.
+
+## Example
+
+```hcl
+resource "lxd_instance" "instance1" {
+  name  = "instance1"
+  image = "ubuntu-daily:22.04"
+
+  # Device attached during instance creation.
+  device {
+    name = "eth0"
+    type = "nic"
+
+    properties = {
+      network = "lxdbr0"
+    }
+  }
+}
+
+resource "lxd_volume" "vol1" {
+  name   = "vol1"
+  pool   = "default"
+  type   = "disk"
+
+  # In case we want to create the volume on the same cluster member
+  # where the instance has been created, the "target" needs to match.
+  #
+  # However, this prevents us from using device block in instance
+  # resource, as it would create a dependency loop. Therefore, we
+  # will use "lxd_instance" resource, which allows device attachment
+  # after instance creation.
+  target = lxd_instance.instance1.location
+
+  config {
+    size = "10GB"
+  }
+}
+
+# Device attachment after instance creation.
+resource "lxd_device" "vol1" {
+  instance     = lxd_instance.instance1.name # Target instance.
+  device_name  = lxd_volume.vol1.name        # Target volume, which is created after instance creation.
+  type         = "disk"
+
+  properties = {
+    path   = "/mnt/vol1"
+    pool   = "default"
+    source = lxd_volume.vol1.name
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - **Required** - Name of the device.
+
+* `instance_name` - **Required** - Name of the instance.
+
+* `project` - *Optional* - Name of the project where the instance to which this device will be attached exists
+
+* `remote` - *Optional* - The remote in which the resource will be created. If
+	not provided, the provider's default remote will be used.
+
+* `target` - *Optional* - Specify a target cluster member or cluster member group of the instance.
+
+* `type` - **Required** - Type of the device Must be one of none, disk, nic,
+	unix-char, unix-block, usb, gpu, infiniband, proxy, unix-hotplug, tpm, pci.
+
+* `properties`- **Required** - Map of key/value pairs of
+	[device properties](https://documentation.ubuntu.com/lxd/latest/reference/devices/).
+
+## Notes
+
+* Terraform LXD provider sets user.managed-by key to all managed instance devices.
+  Removing that key from a device manually, would result in Terraform removing it on next apply.
+

--- a/internal/common/lxd_config.go
+++ b/internal/common/lxd_config.go
@@ -8,6 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// UserManagedBy is used as a config key "user.managed-by" to add additional information about
+// resource owner.
+const UserManagedBy = "user.managed-by"
+
 // ToConfigMap converts config of type types.Map into map[string]string.
 func ToConfigMap(ctx context.Context, configMap types.Map) (map[string]string, diag.Diagnostics) {
 	if configMap.IsNull() || configMap.IsUnknown() {

--- a/internal/common/lxd_device.go
+++ b/internal/common/lxd_device.go
@@ -8,6 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// DeviceManagedByTerraform is used as a value for "user.managed-by" config key to signify that
+// resource is managed by the LXD provider.
+const DeviceManagedByTerraform = "terraform-lxd-provider"
+
 type DeviceModel struct {
 	Name       types.String `tfsdk:"name"`
 	Type       types.String `tfsdk:"type"`

--- a/internal/instance/resource_instance_device.go
+++ b/internal/instance/resource_instance_device.go
@@ -1,0 +1,423 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+
+	lxd "github.com/canonical/lxd/client"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/common"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/errors"
+	provider_config "github.com/terraform-lxd/terraform-provider-lxd/internal/provider-config"
+)
+
+// InstanceDeviceModel represents a single device attached to an LXD instance.
+type InstanceDeviceModel struct {
+	Name         types.String `tfsdk:"name"`
+	InstanceName types.String `tfsdk:"instance_name"`
+	Project      types.String `tfsdk:"project"`
+	Remote       types.String `tfsdk:"remote"`
+	Target       types.String `tfsdk:"target"`
+	Type         types.String `tfsdk:"type"`
+	Properties   types.Map    `tfsdk:"properties"`
+}
+
+// InstanceDeviceResource represents a device attachable to LXD instance.
+type InstanceDeviceResource struct {
+	provider *provider_config.LxdProviderConfig
+}
+
+// NewInstanceDeviceResource returns a new instance device resource.
+func NewInstanceDeviceResource() resource.Resource {
+	return &InstanceDeviceResource{}
+}
+
+// Metadata for the device resource.
+func (r InstanceDeviceResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_instance_device"
+}
+
+// Schema for the device resource.
+func (r InstanceDeviceResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Device name",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+
+			"instance_name": schema.StringAttribute{
+				Required:    true,
+				Description: "Instance name",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+
+			"project": schema.StringAttribute{
+				Optional:    true,
+				Description: "Project",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+
+			"remote": schema.StringAttribute{
+				Optional:    true,
+				Description: "Remote",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+
+			"target": schema.StringAttribute{
+				Optional:    true,
+				Description: "Target",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+
+			"type": schema.StringAttribute{
+				Required:    true,
+				Description: "Device type",
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						"none", "disk", "nic", "unix-char",
+						"unix-block", "usb", "gpu", "infiniband",
+						"proxy", "unix-hotplug", "tpm", "pci",
+					),
+				},
+			},
+
+			"properties": schema.MapAttribute{
+				Required:    true,
+				Description: "Device properties",
+				ElementType: types.StringType,
+				Validators: []validator.Map{
+					mapvalidator.ValueStringsAre(stringvalidator.LengthAtLeast(1)),
+				},
+			},
+		},
+	}
+}
+
+func (r *InstanceDeviceResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.LxdProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+	}
+
+	r.provider = provider
+}
+
+func (r InstanceDeviceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan InstanceDeviceModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := plan.Remote.ValueString()
+	project := plan.Project.ValueString()
+	target := plan.Target.ValueString()
+	server, err := r.provider.InstanceServer(remote, project, target)
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	props, diags := common.ToConfigMap(ctx, plan.Properties)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	instance, etag, err := server.GetInstance(plan.InstanceName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve existing instance %q", plan.InstanceName.ValueString()), err.Error())
+		return
+	}
+
+	deviceName := plan.Name.ValueString()
+	deviceType := plan.Type.ValueString()
+	props["type"] = deviceType
+
+	// Mark the device as managed by terraform to differentiate between
+	// devices added by terraform and devices added manually.
+	props[common.UserManagedBy] = common.DeviceManagedByTerraform
+
+	if instance.Devices == nil {
+		instance.Devices = make(map[string]map[string]string)
+	}
+
+	_, deviceExists := instance.Devices[deviceName]
+	if deviceExists {
+		msg := fmt.Sprintf("Device %q on instance %q already exists", deviceName, instance.Name)
+		resp.Diagnostics.AddError("Device already exists", msg)
+		return
+	}
+
+	// Modify devices map to add the provided device.
+	instance.Devices[deviceName] = props
+
+	updatedInstance := instance.Writable()
+	op, err := server.UpdateInstance(instance.Name, updatedInstance, etag)
+	if err == nil {
+		// Wait for the instance to be updated.
+		err = op.WaitContext(ctx)
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update instance %q", instance.Name), err.Error())
+		return
+	}
+
+	// Sync state after successfully attaching the device.
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r InstanceDeviceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state InstanceDeviceModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	project := state.Project.ValueString()
+	target := state.Target.ValueString()
+	server, err := r.provider.InstanceServer(remote, project, target)
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r InstanceDeviceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan InstanceDeviceModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := plan.Remote.ValueString()
+	project := plan.Project.ValueString()
+	target := plan.Target.ValueString()
+	server, err := r.provider.InstanceServer(remote, project, target)
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	props, diags := common.ToConfigMap(ctx, plan.Properties)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	instance, etag, err := server.GetInstance(plan.InstanceName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve existing instance %q", plan.InstanceName.ValueString()), err.Error())
+		return
+	}
+
+	deviceName := plan.Name.ValueString()
+	deviceType := plan.Type.ValueString()
+	props["type"] = deviceType
+
+	// Mark the device as managed by terraform to differentiate between
+	// devices added by terraform and devices added manually.
+	props[common.UserManagedBy] = common.DeviceManagedByTerraform
+
+	if instance.Devices == nil {
+		msg := fmt.Sprintf("Instance %q has no devices", instance.Name)
+		resp.Diagnostics.AddError("Instance has no devices", msg)
+		return
+	}
+
+	oldDevice, deviceExists := instance.Devices[deviceName]
+	if !deviceExists {
+		msg := fmt.Sprintf("Device %q on instance %q not found", deviceName, instance.Name)
+		resp.Diagnostics.AddError("Device not found", msg)
+		return
+	}
+
+	if oldDevice[common.UserManagedBy] != common.DeviceManagedByTerraform {
+		msg := fmt.Sprintf("Device %q on instance %q is not managed by Terraform", deviceName, instance.Name)
+		resp.Diagnostics.AddError("Cannot update non-managed device", msg)
+		return
+	}
+
+	// Modify devices map to add the provided device.
+	instance.Devices[deviceName] = props
+
+	updatedInstance := instance.Writable()
+	op, err := server.UpdateInstance(instance.Name, updatedInstance, etag)
+	if err == nil {
+		// Wait for the instance to be updated.
+		err = op.WaitContext(ctx)
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update instance %q", instance.Name), err.Error())
+		return
+	}
+
+	// Sync state after successfully updating the device properties.
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r InstanceDeviceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state InstanceDeviceModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	project := state.Project.ValueString()
+	target := state.Target.ValueString()
+	server, err := r.provider.InstanceServer(remote, project, target)
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	instanceName := state.InstanceName.ValueString()
+	deviceName := state.Name.ValueString()
+
+	instance, etag, err := server.GetInstance(instanceName)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve existing instance %q", state.InstanceName.ValueString()), err.Error())
+		return
+	}
+
+	// Skip the update if the device not found.
+	oldDevice, deviceExists := instance.Devices[deviceName]
+	if !deviceExists {
+		return
+	}
+
+	if oldDevice[common.UserManagedBy] != common.DeviceManagedByTerraform {
+		msg := fmt.Sprintf("Device %q on instance %q is not managed by Terraform", deviceName, instance.Name)
+		resp.Diagnostics.AddError("Cannot delete non-managed device", msg)
+		return
+	}
+
+	// Modify devices map to remove specified device.
+	delete(instance.Devices, deviceName)
+
+	updatedInstance := instance.Writable()
+	op, err := server.UpdateInstance(instance.Name, updatedInstance, etag)
+	if err == nil {
+		// Wait for the instance to be updated.
+		err = op.WaitContext(ctx)
+	}
+
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update instance %q", instance.Name), err.Error())
+		return
+	}
+
+	// Sync state after successfully removing the device.
+	diags = r.SyncState(ctx, &resp.State, server, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+// SyncState fetches the server's current state for the device and updates
+// the provided model. It then applies this updated model as the new state
+// in Terraform.
+func (r InstanceDeviceResource) SyncState(ctx context.Context, tfState *tfsdk.State, server lxd.InstanceServer, m InstanceDeviceModel) diag.Diagnostics {
+	var respDiags diag.Diagnostics
+
+	instanceName := m.InstanceName.ValueString()
+	instance, _, err := server.GetInstance(instanceName)
+	if err != nil {
+		if errors.IsNotFoundError(err) {
+			tfState.RemoveResource(ctx)
+			return nil
+		}
+
+		respDiags.AddError(fmt.Sprintf("Failed to retrieve instance %q", instanceName), err.Error())
+		return respDiags
+	}
+
+	deviceName := m.Name.ValueString()
+	deviceProps, ok := instance.Devices[deviceName]
+	if !ok || deviceProps == nil {
+		tfState.RemoveResource(ctx)
+		return nil
+	}
+
+	deviceType, ok := deviceProps["type"]
+	if !ok || deviceType == "" {
+		respDiags.AddError(
+			"Device is missing type",
+			fmt.Sprintf("Device %q for instance %q is missing type field", deviceName, instanceName))
+		return respDiags
+	}
+
+	// Delete to avoid duplication, "type" value is stored separately in DeviceModel.
+	delete(deviceProps, "type")
+
+	// Delete "user.managed-by" key from internal state to avoid config mismatch.
+	delete(deviceProps, common.UserManagedBy)
+
+	properties, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(deviceProps), m.Properties)
+	respDiags.Append(diags...)
+
+	if respDiags.HasError() {
+		return respDiags
+	}
+
+	m.Type = types.StringValue(deviceType)
+	m.Properties = properties
+
+	return tfState.Set(ctx, &m)
+}

--- a/internal/instance/resource_instance_device.go
+++ b/internal/instance/resource_instance_device.go
@@ -143,6 +143,13 @@ func (r *InstanceDeviceResource) Configure(_ context.Context, req resource.Confi
 	r.provider = provider
 }
 
+func (r *InstanceDeviceResource) ModifyPlan(_ context.Context, _ resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	resp.Diagnostics.AddWarning(
+		"lxd_instance_device is experimental",
+		"lxd_instance_device resource is an experimental feature of Terraform LXD Provider and it may change in the future.",
+	)
+}
+
 func (r InstanceDeviceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan InstanceDeviceModel
 

--- a/internal/instance/resource_instance_device_test.go
+++ b/internal/instance/resource_instance_device_test.go
@@ -1,0 +1,197 @@
+package instance_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
+)
+
+func TestAccDevice_basic(t *testing.T) {
+	instanceName := acctest.GenerateName(2, "-")
+	deviceName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDevice_basic(instanceName, deviceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "name", instanceName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "status", "Stopped"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.%", "1"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.type", deviceName), "disk"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.properties.path", deviceName), fmt.Sprintf("/tmp/%s", deviceName)),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.properties.source", deviceName), "/tmp"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDevice_volumeAttach(t *testing.T) {
+	instanceName := acctest.GenerateName(2, "-")
+	poolName := acctest.GenerateName(2, "-")
+	volumeName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Attach a volume to an instance.
+				Config: testAccDevice_volumeAttach(poolName, volumeName, instanceName, "/mnt"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool1", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool1", "driver", "zfs"),
+					resource.TestCheckResourceAttr("lxd_volume.volume1", "name", volumeName),
+					resource.TestCheckResourceAttr("lxd_volume.volume1", "pool", poolName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "name", instanceName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "status", "Stopped"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.%", "1"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.type", volumeName), "disk"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.properties.path", volumeName), "/mnt"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.properties.pool", volumeName), poolName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.properties.source", volumeName), volumeName),
+				),
+			},
+			{
+				// Try reattaching the volume.
+				Config: testAccDevice_volumeAttach(poolName, volumeName, instanceName, "/data"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool1", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool1", "driver", "zfs"),
+					resource.TestCheckResourceAttr("lxd_volume.volume1", "name", volumeName),
+					resource.TestCheckResourceAttr("lxd_volume.volume1", "pool", poolName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "name", instanceName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "status", "Stopped"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.%", "1"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.type", volumeName), "disk"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.properties.path", volumeName), "/data"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.properties.pool", volumeName), poolName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", fmt.Sprintf("devices.%s.properties.source", volumeName), volumeName),
+				),
+			},
+			{
+				// Try detaching the volume.
+				Config: testAccDevice_volumeDetach(poolName, volumeName, instanceName),
+			},
+			{
+				// Validate detaching here. Otherwise, the datasource for lxd instance will
+				// read the state before device resource gets destroyed.
+				// By validating in a separate step with the same config, the final
+				// state should remain the same, but the datasource for lxd instance will
+				// see the changes made in the previous "terraform apply".
+				Config: testAccDevice_volumeDetach(poolName, volumeName, instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool1", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool1", "driver", "zfs"),
+					resource.TestCheckResourceAttr("lxd_volume.volume1", "name", volumeName),
+					resource.TestCheckResourceAttr("lxd_volume.volume1", "pool", poolName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "name", instanceName),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "status", "Stopped"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDevice_basic(instanceName string, deviceName string) string {
+	return fmt.Sprintf(`
+resource "lxd_instance" "inst" {
+   name    = %q
+   image   = %q
+   running = false
+}
+
+resource "lxd_instance_device" "disk_attach" {
+   name = %q
+   instance_name = lxd_instance.inst.name
+   type = "disk"
+   properties = {
+      source = "/tmp"
+      path   = "/tmp/%s"
+   }
+}
+
+data "lxd_instance" "inst" {
+   name = lxd_instance.inst.name
+
+   depends_on = [
+      lxd_instance_device.disk_attach
+   ]
+}
+   `, instanceName, acctest.TestImage, deviceName, deviceName)
+}
+
+func testAccDevice_volumeAttach(poolName string, volumeName string, instanceName string, mountPath string) string {
+	return fmt.Sprintf(`
+resource "lxd_storage_pool" "pool1" {
+  name   = %q
+  driver = "zfs"
+}
+
+resource "lxd_volume" "volume1" {
+  name = %q
+  pool = lxd_storage_pool.pool1.name
+}
+
+resource "lxd_instance" "inst" {
+  name    = %q
+  image   = %q
+  running = false
+}
+
+resource "lxd_instance_device" "vol_attach" {
+   name          = lxd_volume.volume1.name
+   instance_name = lxd_instance.inst.name
+   type          = "disk"
+
+   properties = {
+      path   = %q
+      source = lxd_volume.volume1.name
+      pool   = lxd_storage_pool.pool1.name
+   }
+}
+
+data "lxd_instance" "inst" {
+   name = lxd_instance.inst.name
+
+   depends_on = [
+      lxd_instance_device.vol_attach
+   ]
+}
+	`, poolName, volumeName, instanceName, acctest.TestImage, mountPath)
+}
+
+func testAccDevice_volumeDetach(poolName string, volumeName string, instanceName string) string {
+	return fmt.Sprintf(`
+resource "lxd_storage_pool" "pool1" {
+  name   = %q
+  driver = "zfs"
+}
+
+resource "lxd_volume" "volume1" {
+  name = %q
+  pool = lxd_storage_pool.pool1.name
+}
+
+resource "lxd_instance" "inst" {
+  name    = %q
+  image   = %q
+  running = false
+}
+
+data "lxd_instance" "inst" {
+   name = lxd_instance.inst.name
+}
+	`, poolName, volumeName, instanceName, acctest.TestImage)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -251,6 +251,7 @@ func (p *LxdProvider) Resources(_ context.Context) []func() resource.Resource {
 		instance.NewInstanceResource,
 		instance.NewInstanceFileResource,
 		instance.NewInstanceSnapshotResource,
+		instance.NewInstanceDeviceResource,
 		network.NewNetworkResource,
 		network.NewNetworkAclResource,
 		network.NewNetworkForwardResource,


### PR DESCRIPTION
This PR adds `InstanceDeviceResource` that allows attaching devices to an instance after it was created. This can be particularly useful for attaching volumes to an instance with initially unknown location in the cluster.

**TODO**:

- [x] Add `user.managed-by: terraform-lxd-provider` config values to devices managed by Terraform to differentiate between infrastructure vs manually added devices.
- [x] Remove any manually added devices.
- [ ] Add tests for coexisting devices in the `instance` resource definition and in `device` resource.
- [ ] Add tests for clustered volume attachment to instances.
