### PR TITLE
tests/instance: Use different network address to prevent race condition

### DIFF
--- a/internal/instance/datasource_instance_test.go
+++ b/internal/instance/datasource_instance_test.go
@@ -119,7 +119,7 @@ func TestAccInstance_DS_accessInterface(t *testing.T) {
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.nictype", "bridged"),
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.parent", networkName),
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.hwaddr", "00:16:3e:39:7f:36"),
-					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.ipv4.address", "10.150.19.200"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.ipv4.address", "10.151.19.200"),
 					resource.TestCheckNoResourceAttr("data.lxd_instance.inst", "mac_address"),
 					resource.TestCheckNoResourceAttr("data.lxd_instance.inst", "ipv4_address"),
 					resource.TestCheckNoResourceAttr("data.lxd_instance.inst", "ipv6_address"),
@@ -132,7 +132,7 @@ func TestAccInstance_DS_accessInterface(t *testing.T) {
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "name", instanceName),
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "status", "Running"),
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "mac_address", "00:16:3e:39:7f:36"),
-					resource.TestCheckResourceAttr("data.lxd_instance.inst", "ipv4_address", "10.150.19.200"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "ipv4_address", "10.151.19.200"),
 					resource.TestCheckResourceAttrSet("data.lxd_instance.inst", "ipv6_address"),
 				),
 			},
@@ -241,7 +241,7 @@ resource "lxd_network" "net" {
   name = %q
 
   config = {
-    "ipv4.address" = "10.150.19.1/24"
+    "ipv4.address" = "10.151.19.1/24"
   }
 }
 
@@ -262,7 +262,7 @@ resource "lxd_instance" "inst" {
       nictype        = "bridged"
       parent         = "${lxd_network.net.name}"
       hwaddr         = "00:16:3e:39:7f:36"
-      "ipv4.address" = "10.150.19.200"
+      "ipv4.address" = "10.151.19.200"
     }
   }
 }

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -1143,7 +1143,7 @@ func TestAccInstance_accessInterface(t *testing.T) {
 				Config: testAccInstance_accessInterface(networkName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.network1", "name", networkName),
-					resource.TestCheckResourceAttr("lxd_network.network1", "config.ipv4.address", "10.150.19.1/24"),
+					resource.TestCheckResourceAttr("lxd_network.network1", "config.ipv4.address", "10.151.19.1/24"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "config.%", "1"),
@@ -1154,9 +1154,9 @@ func TestAccInstance_accessInterface(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.nictype", "bridged"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.parent", networkName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.hwaddr", "00:16:3e:39:7f:36"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.ipv4.address", "10.150.19.200"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.ipv4.address", "10.151.19.200"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "mac_address", "00:16:3e:39:7f:36"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "ipv4_address", "10.150.19.200"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "ipv4_address", "10.151.19.200"),
 					resource.TestCheckResourceAttrSet("lxd_instance.instance1", "ipv6_address"),
 				),
 			},
@@ -2162,7 +2162,7 @@ resource "lxd_network" "network1" {
   name = "%s"
 
   config = {
-    "ipv4.address" = "10.150.19.1/24"
+    "ipv4.address" = "10.151.19.1/24"
   }
 }
 
@@ -2182,7 +2182,7 @@ resource "lxd_instance" "instance1" {
       nictype        = "bridged"
       parent         = "${lxd_network.network1.name}"
       hwaddr         = "00:16:3e:39:7f:36"
-      "ipv4.address" = "10.150.19.200"
+      "ipv4.address" = "10.151.19.200"
     }
   }
 }


### PR DESCRIPTION
Using the same network address in network and instance resource tests causes race condition because tests in different packages are run in parallel.