### PR TITLE
workflows/release: Add write content perm for token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   goreleaser:
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Add `contents: write` permission to release workflow to allow goreleaser to publish built binaries under the release