### PR TITLE
goreleaser: replace deprecated `archives.format`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,7 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: [ 'zip' ]
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'


### PR DESCRIPTION
https://goreleaser.com/deprecations/#archivesformat