### PR TITLE
docs: Fix network forward import ID syntax

### DIFF
--- a/docs/resources/network_forward.md
+++ b/docs/resources/network_forward.md
@@ -77,7 +77,7 @@ The network forward port supports:
 
 ## Importing
 
-Import ID syntax: `[<remote>:][<project>/]<network>/<listen-address>`
+Import ID syntax: `[<remote>:][<project>]/<network>/<listen-address>`
 
 * `<remote>` - *Optional* - Remote name.
 * `<project>` - *Optional* - Project name.


### PR DESCRIPTION
Fixes import ID syntax in docs for network forward (when there are two required fields, first `/` is not optional).
Related to: https://github.com/terraform-lxd/terraform-provider-lxd/issues/628

Terraform error prints it correctly:
```
│ Error: Invalid import ID: "lxdbr0/2001:db8::1"
│ 
│ Import ID does not contain all required fields: [network, listen_address].
│ 
│ Valid import format:
│ import lxd_network_forward.<resource> [<remote>:][<project>]/<network>/<listen_address>
```