### PR TITLE
network: Fix OVN creation and add cluster tests

### DIFF
--- a/.github/actions/cluster/action.yml
+++ b/.github/actions/cluster/action.yml
@@ -16,6 +16,9 @@ inputs:
   lxd-version:
     description: The version of LXD to install on each cluster member.
     default: latest/edge
+  enable-ovn:
+    description: Install and configure OVN on cluster members.
+    default: "false"
 
 runs:
   using: composite
@@ -52,3 +55,4 @@ runs:
         INSTANCE_TYPE: ${{ inputs.instance-type }}
         INSTANCE_IMAGE: ubuntu:24.04
         VERSION_LXD: ${{ inputs.lxd-version }}
+        MICROOVN_ENABLED: ${{ inputs.enable-ovn }}

--- a/.github/actions/cluster/lxd-cluster.sh
+++ b/.github/actions/cluster/lxd-cluster.sh
@@ -16,8 +16,13 @@ INSTANCE_IMAGE="${INSTANCE_IMAGE:-ubuntu:24.04}"
 # Type of cluster instances (container or virtual-machine).
 INSTANCE_TYPE="${INSTANCE_TYPE:-container}"
 
-# Version of LXD to install.
+# Component versions.
 VERSION_LXD="${VERSION_LXD:-latest/edge}"
+VERSION_MICROOVN="${VERSION_MICROOVN:-latest/edge}"
+
+# MicroOVN configuration.
+MICROOVN_ENABLED="${MICROOVN_ENABLED:-false}"
+MICROOVN_PKI_DIR="/var/snap/microovn/common/data/pki"
 
 # MinIO configuration.
 MINIO_ENABLED="${MINIO_ENABLED:-true}"
@@ -77,7 +82,6 @@ instanceIPv4() {
         echo "Error: Failed to obtain IPv4 address of instance ${instance}"
         return 1
 }
-
 
 #========================
 # Cluster setup
@@ -262,6 +266,8 @@ EOF
                 lxc exec "${LEADER}" -- lxc profile device add default eth0 nic nictype=bridged parent=lxdbr0
         fi
 
+        configure_ovn
+
         # Configure new cluster remote.
         token=$(lxc exec "${LEADER}" -- lxc config trust add --name host --quiet)
         ipv4=$(instanceIPv4 "${LEADER}")
@@ -274,6 +280,79 @@ EOF
         lxc cluster list "${CLUSTER_NAME}:"
 }
 
+# configure_ovn installs and configures MicroOVN on LXD cluster members.
+configure_ovn() {
+        if [ "${MICROOVN_ENABLED}" != "true" ]; then
+                echo "OVN setup disabled."
+                return
+        fi
+
+        if [ "${INSTANCE_TYPE}" != "virtual-machine" ]; then
+                echo "Error: OVN setup requires virtual-machine cluster members."
+                exit 1
+        fi
+
+        echo "Installing MicroOVN on cluster members ..."
+
+        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                instance="${INSTANCE}-${i}"
+                lxc exec "${instance}" -- snap install microovn --channel "${VERSION_MICROOVN}"
+
+                if lxc exec "${instance}" -- snap connections lxd | grep -qwF lxd:ovn-certificates; then
+                        lxc exec "${instance}" -- snap connect lxd:ovn-certificates microovn:ovn-certificates
+                        lxc exec "${instance}" -- snap connect lxd:ovn-chassis microovn:ovn-chassis
+                fi
+        done
+
+        echo "Forming MicroOVN cluster ..."
+
+        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                instance="${INSTANCE}-${i}"
+
+                # On the leader instance, bootstrap a new MicroOVN cluster and continue.
+                if [ "${instance}" = "${LEADER}" ]; then
+                        lxc exec "${instance}" -- microovn cluster bootstrap
+                        continue
+                fi
+
+                # Create and extract a join token for a new cluster member.
+                token=$(lxc exec "${LEADER}" -- microovn cluster add "${instance}")
+                if [ "${token}" = "" ]; then
+                        echo "Error: Failed retrieving MicroOVN join token for instance ${instance}"
+                        exit 1
+                fi
+
+                lxc exec "${instance}" -- microovn cluster join "${token}"
+        done
+
+        # Wait for MicroOVN to become ready on all members.
+        for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                instance="${INSTANCE}-${i}"
+                lxc exec "${instance}" -- microovn waitready
+        done
+
+        if ! info=$(lxc exec "${LEADER}" -- lxc info); then
+                echo "Failed to get LXD info from ${LEADER}"
+                exit 1
+        fi
+
+        if ! echo "${info}" | grep -qxF -- "- ovn_dynamic_northbound_connection"; then
+                # LXD 5.0 resolves OVN southbound info through host ovs-vsctl and uses legacy OVN
+                # client cert paths.
+                for i in $(seq 1 "${CLUSTER_SIZE}"); do
+                        instance="${INSTANCE}-${i}"
+
+                        lxc exec "${instance}" -- mkdir -p /var/run/openvswitch /etc/ovn
+                        lxc exec "${instance}" -- ln -sf /var/snap/microovn/common/run/switch/db.sock /var/run/openvswitch/db.sock
+                        lxc exec "${instance}" -- ln -sf "${MICROOVN_PKI_DIR}/client-cert.pem" /etc/ovn/cert_host
+                        lxc exec "${instance}" -- ln -sf "${MICROOVN_PKI_DIR}/client-privkey.pem" /etc/ovn/key_host
+                        lxc exec "${instance}" -- ln -sf "${MICROOVN_PKI_DIR}/cacert.pem" /etc/ovn/ovn-central.crt
+                done
+
+                leaderIPv4=$(instanceIPv4 "${LEADER}")
+                lxc exec "${LEADER}" -- lxc config set network.ovn.northbound_connection="ssl:${leaderIPv4}:6641"
+        fi
+}
 
 #================================================
 # Cleanup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,8 @@ jobs:
 
       - name: Run acceptance tests
         run: make test
+        env:
+          LXD_TEST_SKIP_VMS: "true"
 
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,10 @@ jobs:
         uses: ./.github/actions/cluster
         with:
           cluster-name: acctest
+          cluster-size: 2
+          instance-type: virtual-machine
           lxd-version: ${{ matrix.channel }}
+          enable-ovn: true
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1

--- a/internal/acctest/checks.go
+++ b/internal/acctest/checks.go
@@ -28,6 +28,13 @@ func PreCheck(t *testing.T) {
 	// }
 }
 
+// PreCheckVMTests skips VM tests if the LXD_TEST_SKIP_VMS environment variable is set.
+func PreCheckVMTests(t *testing.T) {
+	if shared.IsTrue(os.Getenv("LXD_TEST_SKIP_VMS")) {
+		t.Skipf("Test %q skipped. VM tests are disabled because LXD_TEST_SKIP_VMS is set.", t.Name())
+	}
+}
+
 // PreCheckLxdVersion skips the test if the server's version does not satisfy
 // the provided version constraints. The version constraints are detailed at:
 // https://pkg.go.dev/github.com/hashicorp/go-version#readme-version-constraints

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -74,7 +74,10 @@ func TestAccInstance_empty_vm(t *testing.T) {
 
 	instanceName := acctest.GenerateName(2, "-")
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(t) },
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckVMTests(t)
+		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -129,6 +132,7 @@ func TestAccInstance_virtualMachine(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckVMTests(t)
 			acctest.PreCheckVirtualization(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -193,6 +197,7 @@ func TestAccInstance_restartVirtualMachine(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckVMTests(t)
 			acctest.PreCheckVirtualization(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -631,6 +636,7 @@ func TestAccInstance_fileUploadVirtualMachine(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckVMTests(t)
 			acctest.PreCheckVirtualization(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -1151,6 +1157,7 @@ func TestAccInstance_vm_configLimits(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckVMTests(t)
 			acctest.PreCheckVirtualization(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -1534,6 +1541,7 @@ func TestAccInstance_waitForAgent(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
+			acctest.PreCheckVMTests(t)
 			acctest.PreCheckVirtualization(t)
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -314,6 +315,14 @@ func (r NetworkResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	if networkType == "ovn" {
+		err := waitActiveOVNChassis(ctx, server, networkName)
+		if err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Failed to wait for OVN network %q to become available", networkName), err.Error())
+			return
+		}
+	}
+
 	// Update Terraform state.
 	diags = r.SyncState(ctx, &resp.State, server, plan)
 	resp.Diagnostics.Append(diags...)
@@ -415,6 +424,14 @@ func (r NetworkResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update network %q", networkName), err.Error())
 		return
+	}
+
+	if networkType == "ovn" {
+		err := waitActiveOVNChassis(ctx, server, networkName)
+		if err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Failed to wait for OVN network %q to become available", networkName), err.Error())
+			return
+		}
 	}
 
 	// Update Terraform state.
@@ -785,4 +802,36 @@ func findGlobalCIDRs(addrs []api.NetworkStateAddress) (ipv4 string, ipv6 string)
 	}
 
 	return ipv4, ipv6
+}
+
+// waitActiveOVNChassis waits until OVN network reports an active chassis in its state.
+func waitActiveOVNChassis(ctx context.Context, server lxd.InstanceServer, networkName string) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		// Reset error each loop to avoid returning stale error.
+		lastErr = nil
+
+		state, err := server.GetNetworkState(networkName)
+		if err != nil {
+			lastErr = fmt.Errorf("Failed to retrieve state of OVN network %q: %w", networkName, err)
+		} else if state.OVN != nil && state.OVN.Chassis != "" {
+			return nil
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			if lastErr != nil {
+				return lastErr
+			}
+
+			return fmt.Errorf("Timed out waiting for OVN network %q to have an active chassis: %w", networkName, ctx.Err())
+		}
+	}
 }

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -626,10 +626,10 @@ func (m NetworkModel) ParseNetworkConfigs(ctx context.Context, server lxd.Instan
 
 	hasMemberOverrides := len(m.MemberOverrides.Elements()) > 0
 
-	// Return early if LXD is not clustered.
-	if !isServerClustered {
+	// Return early if LXD is not clustered or network type is OVN.
+	if !isServerClustered || networkType == "ovn" {
 		if hasMemberOverrides {
-			return nil, nil, fmt.Errorf("Network %q (%s) member-specific config overrides are allowed only when LXD is clustered", networkName, networkType)
+			return nil, nil, fmt.Errorf(`Network %q (%s) cannot use member-specific config overrides unless LXD is clustered and the network type is not "ovn"`, networkName, networkType)
 		}
 
 		// Return early with global network config.

--- a/internal/network/resource_network_lb_test.go
+++ b/internal/network/resource_network_lb_test.go
@@ -14,7 +14,6 @@ func TestAccNetworkLB_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -46,7 +45,6 @@ func TestAccNetworkLB_withConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -139,7 +137,6 @@ func TestAccNetworkLB_withBackendAndPort(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -186,7 +183,6 @@ func TestAccNetworkLB_withBackendAndPort_noDescriptions(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckStandalone(t)
 			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,

--- a/internal/network/resource_network_peer_test.go
+++ b/internal/network/resource_network_peer_test.go
@@ -13,10 +13,7 @@ func TestAccNetworkPeer_basic(t *testing.T) {
 	dstNetwork := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckStandalone(t) // Due to standalone network creation.
-		},
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -48,10 +45,7 @@ func TestAccNetworkPeer_import(t *testing.T) {
 	dstNetwork := acctest.GenerateName(2, "-")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckStandalone(t) // Due to standalone network creation.
-		},
+		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
This PR:
- Fixes OVN creation (prevent per-member network operations when network type is `ovn`)
- Wait for OVN to have active chassis after any changes
- Test OVN in cluster