### PR TITLE
network/test: Fix flaky test by waiting for network

### DIFF
--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -503,6 +503,14 @@ resource "lxd_instance" "instance1" {
   name     = "%s"
   image    = "%s"
   profiles = ["default", lxd_profile.profile1.name]
+
+  wait_for {
+    type = "ipv4"
+  }
+
+  wait_for {
+    type = "ipv6"
+  }
 }
 `, networkName, profileName, instanceName, acctest.TestImage)
 }


### PR DESCRIPTION
Network attach from profile test is flaky because it expects ipv4/6 to be set, but does not wait for one.