### PR TITLE
instance/test: Do not wait for ip addresses in restart test

### DIFF
--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -161,8 +161,6 @@ func TestAccInstance_restartContainer(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "running", "true"),
 					resource.TestCheckResourceAttrSet("lxd_instance.instance1", "mac_address"),
-					resource.TestCheckResourceAttrSet("lxd_instance.instance1", "ipv4_address"),
-					resource.TestCheckResourceAttrSet("lxd_instance.instance1", "ipv6_address"),
 				),
 			},
 			{
@@ -205,8 +203,6 @@ func TestAccInstance_restartVirtualMachine(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "running", "true"),
 					resource.TestCheckResourceAttrSet("lxd_instance.instance1", "mac_address"),
-					resource.TestCheckResourceAttrSet("lxd_instance.instance1", "ipv4_address"),
-					resource.TestCheckResourceAttrSet("lxd_instance.instance1", "ipv6_address"),
 				),
 			},
 			{


### PR DESCRIPTION
Another flaky test where ips are expected but not waited for.
There are several tests waiting for IP on creating, so to speed up a bit, let's not even wait for them in restart test.