### PR TITLE
tests: Generate unique IP and MAC addresses

### DIFF
--- a/internal/acctest/testutils.go
+++ b/internal/acctest/testutils.go
@@ -133,3 +133,18 @@ func (s Subnet) SubRangeV6(sub int) string {
 	prefix := fmt.Sprintf("%s:%x::", strings.TrimSuffix(s.ipv6, "::"), sub)
 	return fmt.Sprintf("%s-%sffff", prefix, prefix)
 }
+
+// GenerateMACAddress generates a random locally-administered MAC address.
+func GenerateMACAddress() string {
+	usedAddrsLock.Lock()
+	defer usedAddrsLock.Unlock()
+
+	for {
+		mac := fmt.Sprintf("02:16:3e:%02x:%02x:%02x", rand.IntN(256), rand.IntN(256), rand.IntN(256))
+		_, ok := usedAddrs[mac]
+		if !ok {
+			usedAddrs[mac] = struct{}{}
+			return mac
+		}
+	}
+}

--- a/internal/acctest/testutils.go
+++ b/internal/acctest/testutils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strings"
+	"sync"
 
 	petname "github.com/dustinkirkland/golang-petname"
 )
@@ -37,4 +38,98 @@ func QuoteStrings(slice []string) string {
 		quoted[i] = fmt.Sprintf("%q", s)
 	}
 	return strings.Join(quoted, ", ")
+}
+
+var usedAddrsLock = sync.Mutex{}
+var usedAddrs = make(map[string]struct{})
+
+// Subnet represents a randomly generated private subnet, with both an IPv4
+// and IPv6 range, used to avoid address collisions between acceptance tests
+// that create networks.
+type Subnet struct {
+	ipv4 string
+	ipv6 string
+}
+
+// GenerateSubnet generates a random private /24 IPv4 subnet and a random
+// private /64 IPv6 subnet.
+func GenerateSubnet() Subnet {
+	randomIPv4 := func() string {
+		// Use private IPv4 range 10.11.0.0 - 10.255.255.0.
+		// This avoids conflicts with the private IPs used by GitHub runners.
+		return fmt.Sprintf("10.%d.%d.0", rand.IntN(245)+11, rand.IntN(256))
+	}
+
+	randomIPv6 := func() string {
+		return fmt.Sprintf("fd42:%x:%x:%x::", rand.IntN(0x10000), rand.IntN(0x10000), rand.IntN(0x10000))
+	}
+
+	findUniqueIP := func(newIP func() string) string {
+		usedAddrsLock.Lock()
+		defer usedAddrsLock.Unlock()
+
+		for {
+			ip := newIP()
+			_, used := usedAddrs[ip]
+			if !used {
+				usedAddrs[ip] = struct{}{}
+				return ip
+			}
+		}
+	}
+
+	return Subnet{
+		ipv4: findUniqueIP(randomIPv4),
+		ipv6: findUniqueIP(randomIPv6),
+	}
+}
+
+// GatewayCIDRv4 returns the IPv4 gateway address in CIDR notation.
+// Example: "10.123.45.1/24".
+func (s Subnet) GatewayCIDRv4() string {
+	return s.HostIPv4(1) + "/24"
+}
+
+// GatewayCIDRv6 returns the IPv6 gateway address in CIDR notation.
+// Example: "fd42:1:2:3::1/64".
+func (s Subnet) GatewayCIDRv6() string {
+	return s.HostIPv6(1) + "/64"
+}
+
+// HostIPv4 returns the address of the given host within the IPv4 subnet.
+// Example: HostIPv4(200) returns "10.123.45.200".
+func (s Subnet) HostIPv4(host int) string {
+	return fmt.Sprintf("%s.%d", strings.TrimSuffix(s.ipv4, ".0"), host)
+}
+
+// HostIPv6 returns the address of the given host within the IPv6 subnet.
+// Example: HostIPv6(200) returns "fd42:1:2:3::c8".
+func (s Subnet) HostIPv6(host int) string {
+	return fmt.Sprintf("%s%x", s.ipv6, host)
+}
+
+// RangeV4 returns the IPv4 subnet range.
+// Example: "10.123.45.0-10.123.45.255".
+func (s Subnet) RangeV4() string {
+	return fmt.Sprintf("%s-%s", s.HostIPv4(0), s.HostIPv4(255))
+}
+
+// RangeV6 returns the IPv6 subnet range.
+// Example: "fd42:1:2:3::-fd42:1:2:3::ffff:ffff:ffff:ffff".
+func (s Subnet) RangeV6() string {
+	return fmt.Sprintf("%s-%s", s.HostIPv6(0), s.ipv6+"ffff:ffff:ffff:ffff")
+}
+
+// SubRangeV4 returns the address range between the two given hosts within the IPv4 subnet.
+// Example: SubRangeV4(100, 150) returns "10.123.45.100-10.123.45.150".
+func (s Subnet) SubRangeV4(fromHost int, toHost int) string {
+	return fmt.Sprintf("%s-%s", s.HostIPv4(fromHost), s.HostIPv4(toHost))
+}
+
+// SubRangeV6 returns the address range of a sub-block within the /64 subnet, identified
+// by the given sub-block number (encoded in the next hextet).
+// Example: SubRangeV6(10) returns "fd42:1:2:3:a::-fd42:1:2:3:a::ffff".
+func (s Subnet) SubRangeV6(sub int) string {
+	prefix := fmt.Sprintf("%s:%x::", strings.TrimSuffix(s.ipv6, "::"), sub)
+	return fmt.Sprintf("%s-%sffff", prefix, prefix)
 }

--- a/internal/instance/datasource_instance_test.go
+++ b/internal/instance/datasource_instance_test.go
@@ -99,6 +99,9 @@ func TestAccInstance_DS_accessInterface(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 	instanceName := acctest.GenerateName(2, "-")
 
+	subnet := acctest.GenerateSubnet()
+	mac := acctest.GenerateMACAddress()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
@@ -108,7 +111,7 @@ func TestAccInstance_DS_accessInterface(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Create stopped instance. No address should be available.
-				Config: acctest.Provider() + testAccInstance_DS_accessInterface(networkName, instanceName, false),
+				Config: acctest.Provider() + testAccInstance_DS_accessInterface(networkName, instanceName, subnet, mac, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "name", instanceName),
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "status", "Stopped"),
@@ -117,8 +120,8 @@ func TestAccInstance_DS_accessInterface(t *testing.T) {
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.type", "nic"),
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.nictype", "bridged"),
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.parent", networkName),
-					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.hwaddr", "00:16:3e:39:7f:36"),
-					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.ipv4.address", "10.151.19.200"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.hwaddr", mac),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "devices.eth0.properties.ipv4.address", subnet.HostIPv4(200)),
 					resource.TestCheckNoResourceAttr("data.lxd_instance.inst", "mac_address"),
 					resource.TestCheckNoResourceAttr("data.lxd_instance.inst", "ipv4_address"),
 					resource.TestCheckNoResourceAttr("data.lxd_instance.inst", "ipv6_address"),
@@ -126,12 +129,12 @@ func TestAccInstance_DS_accessInterface(t *testing.T) {
 			},
 			{
 				// Start the instance to ensure the addresses get populated.
-				Config: acctest.Provider() + testAccInstance_DS_accessInterface(networkName, instanceName, true),
+				Config: acctest.Provider() + testAccInstance_DS_accessInterface(networkName, instanceName, subnet, mac, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "name", instanceName),
 					resource.TestCheckResourceAttr("data.lxd_instance.inst", "status", "Running"),
-					resource.TestCheckResourceAttr("data.lxd_instance.inst", "mac_address", "00:16:3e:39:7f:36"),
-					resource.TestCheckResourceAttr("data.lxd_instance.inst", "ipv4_address", "10.151.19.200"),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "mac_address", mac),
+					resource.TestCheckResourceAttr("data.lxd_instance.inst", "ipv4_address", subnet.HostIPv4(200)),
 					resource.TestCheckResourceAttrSet("data.lxd_instance.inst", "ipv6_address"),
 				),
 			},
@@ -227,13 +230,13 @@ data "lxd_instance" "inst" {
   `, name)
 }
 
-func testAccInstance_DS_accessInterface(networkName string, instanceName string, running bool) string {
+func testAccInstance_DS_accessInterface(networkName string, instanceName string, subnet acctest.Subnet, mac string, running bool) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "net" {
   name = %q
 
   config = {
-    "ipv4.address" = "10.151.19.1/24"
+    "ipv4.address" = %q
   }
 }
 
@@ -253,8 +256,8 @@ resource "lxd_instance" "inst" {
     properties = {
       nictype        = "bridged"
       parent         = "${lxd_network.net.name}"
-      hwaddr         = "00:16:3e:39:7f:36"
-      "ipv4.address" = "10.151.19.200"
+      hwaddr         = %q
+      "ipv4.address" = %q
     }
   }
 }
@@ -262,7 +265,7 @@ resource "lxd_instance" "inst" {
 data "lxd_instance" "inst" {
   name = lxd_instance.inst.name
 }
-  `, networkName, instanceName, acctest.TestImage, running)
+  `, networkName, subnet.HostIPv4(1)+"/24", instanceName, acctest.TestImage, running, mac, subnet.HostIPv4(200))
 }
 
 func testAccInstance_DS_project(projectName string, instanceName string) string {

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -1210,6 +1210,8 @@ func TestAccInstance_vm_configLimits(t *testing.T) {
 func TestAccInstance_accessInterface(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 	instanceName := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
+	mac := acctest.GenerateMACAddress()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -1219,10 +1221,10 @@ func TestAccInstance_accessInterface(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccInstance_accessInterface(networkName, instanceName),
+				Config: acctest.Provider() + testAccInstance_accessInterface(networkName, instanceName, subnet, mac),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.network1", "name", networkName),
-					resource.TestCheckResourceAttr("lxd_network.network1", "config.ipv4.address", "10.151.19.1/24"),
+					resource.TestCheckResourceAttr("lxd_network.network1", "config.ipv4.address", subnet.HostIPv4(1)+"/24"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "config.%", "1"),
@@ -1232,10 +1234,10 @@ func TestAccInstance_accessInterface(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.type", "nic"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.nictype", "bridged"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.parent", networkName),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.hwaddr", "00:16:3e:39:7f:36"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.ipv4.address", "10.151.19.200"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "mac_address", "00:16:3e:39:7f:36"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "ipv4_address", "10.151.19.200"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.hwaddr", mac),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.ipv4.address", subnet.HostIPv4(200)),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "mac_address", mac),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "ipv4_address", subnet.HostIPv4(200)),
 					resource.TestCheckResourceAttrSet("lxd_instance.instance1", "ipv6_address"),
 				),
 			},
@@ -1247,6 +1249,8 @@ func TestAccInstance_accessInterfaceFromProfile(t *testing.T) {
 	instanceName := acctest.GenerateName(2, "-")
 	profileName := acctest.GenerateName(2, "-")
 	networkName := acctest.GenerateName(1, "-")
+	subnet0 := acctest.GenerateSubnet()
+	subnet1 := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -1257,7 +1261,7 @@ func TestAccInstance_accessInterfaceFromProfile(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Start the instance and ensure address from eht0 is reported.
-				Config: acctest.Provider() + testAccInstance_accessInterfaceFromProfile(networkName, profileName, instanceName, "eth0"),
+				Config: acctest.Provider() + testAccInstance_accessInterfaceFromProfile(networkName, profileName, instanceName, "eth0", subnet0, subnet1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_profile.profile", "name", profileName),
 					resource.TestCheckResourceAttr("lxd_profile.profile", "config.user.access_interface", "eth0"),
@@ -1267,12 +1271,12 @@ func TestAccInstance_accessInterfaceFromProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.name", "eth0"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.parent", fmt.Sprintf("%s-0", networkName)),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.hwaddr", "00:16:3e:39:7f:37"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.ipv4.address", "10.150.20.200"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.properties.ipv4.address", subnet0.HostIPv4(200)),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.1.name", "eth1"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.1.properties.parent", fmt.Sprintf("%s-1", networkName)),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.1.properties.hwaddr", "00:16:3e:39:7f:38"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.1.properties.ipv4.address", "10.151.21.200"),
-					resource.TestCheckResourceAttr("lxd_instance.instance1", "ipv4_address", "10.150.20.200"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.1.properties.ipv4.address", subnet1.HostIPv4(200)),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "ipv4_address", subnet0.HostIPv4(200)),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "mac_address", "00:16:3e:39:7f:37"),
 				),
 			},
@@ -1578,6 +1582,7 @@ func TestAccInstance_waitForDelay(t *testing.T) {
 func TestAccInstance_waitForIPv4(t *testing.T) {
 	networkName := acctest.GenerateName(1, "-")
 	instanceName := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -1587,7 +1592,7 @@ func TestAccInstance_waitForIPv4(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccInstance_waitForIPv4(networkName, instanceName),
+				Config: acctest.Provider() + testAccInstance_waitForIPv4(networkName, instanceName, subnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
@@ -1602,6 +1607,7 @@ func TestAccInstance_waitForIPv4(t *testing.T) {
 func TestAccInstance_waitForIPv6(t *testing.T) {
 	networkName := acctest.GenerateName(1, "-")
 	instanceName := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -1611,7 +1617,7 @@ func TestAccInstance_waitForIPv6(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccInstance_waitForIPv6(networkName, instanceName),
+				Config: acctest.Provider() + testAccInstance_waitForIPv6(networkName, instanceName, subnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
@@ -1626,6 +1632,7 @@ func TestAccInstance_waitForIPv6(t *testing.T) {
 func TestAccInstance_waitForIPv4AndIPv6(t *testing.T) {
 	networkName := acctest.GenerateName(1, "-")
 	instanceName := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -1635,7 +1642,7 @@ func TestAccInstance_waitForIPv4AndIPv6(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccInstance_waitForIPv4AndIPv6(networkName, instanceName),
+				Config: acctest.Provider() + testAccInstance_waitForIPv4AndIPv6(networkName, instanceName, subnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
@@ -2383,13 +2390,13 @@ resource "lxd_instance" "instance1" {
 	`, name, acctest.TestImage, allowRestart, cpu, memory, acctest.DisableSecureBootConfigEntry())
 }
 
-func testAccInstance_accessInterface(networkName string, instanceName string) string {
+func testAccInstance_accessInterface(networkName string, instanceName string, subnet acctest.Subnet, mac string) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network1" {
   name = "%s"
 
   config = {
-    "ipv4.address" = "10.151.19.1/24"
+    "ipv4.address" = "%s"
   }
 }
 
@@ -2413,21 +2420,21 @@ resource "lxd_instance" "instance1" {
     properties = {
       nictype        = "bridged"
       parent         = "${lxd_network.network1.name}"
-      hwaddr         = "00:16:3e:39:7f:36"
-      "ipv4.address" = "10.151.19.200"
+      hwaddr         = "%s"
+      "ipv4.address" = "%s"
     }
   }
 }
-	`, networkName, instanceName, acctest.TestImage)
+	`, networkName, subnet.HostIPv4(1)+"/24", instanceName, acctest.TestImage, mac, subnet.HostIPv4(200))
 }
 
-func testAccInstance_accessInterfaceFromProfile(networkName string, profileName string, instanceName string, accInterface string) string {
+func testAccInstance_accessInterfaceFromProfile(networkName string, profileName string, instanceName string, accInterface string, subnet1 acctest.Subnet, subnet2 acctest.Subnet) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network0" {
   name = "%[1]s-0"
 
   config = {
-    "ipv4.address" = "10.150.20.1/24"
+    "ipv4.address" = "%[6]s"
   }
 }
 
@@ -2435,21 +2442,21 @@ resource "lxd_network" "network1" {
   name = "%[1]s-1"
 
   config = {
-    "ipv4.address" = "10.151.21.1/24"
+    "ipv4.address" = "%[7]s"
   }
 }
 
 resource "lxd_profile" "profile" {
-  name = "%s"
+  name = "%[2]s"
 
   config = {
-    "user.access_interface" = "%s"
+    "user.access_interface" = "%[3]s"
   }
 }
 
 resource "lxd_instance" "instance1" {
-  name     = "%s"
-  image    = "%s"
+  name     = "%[4]s"
+  image    = "%[5]s"
   profiles = ["default", lxd_profile.profile.name]
 
   device {
@@ -2460,7 +2467,7 @@ resource "lxd_instance" "instance1" {
       nictype        = "bridged"
       parent         = "${lxd_network.network0.name}"
       hwaddr         = "00:16:3e:39:7f:37"
-      "ipv4.address" = "10.150.20.200"
+      "ipv4.address" = "%[8]s"
     }
   }
 
@@ -2472,7 +2479,7 @@ resource "lxd_instance" "instance1" {
       nictype        = "bridged"
       parent         = "${lxd_network.network1.name}"
       hwaddr         = "00:16:3e:39:7f:38"
-      "ipv4.address" = "10.151.21.200"
+      "ipv4.address" = "%[9]s"
     }
   }
 
@@ -2487,7 +2494,17 @@ resource "lxd_instance" "instance1" {
     EOF
   }
 }
-	`, networkName, profileName, accInterface, instanceName, acctest.TestImage)
+	`,
+		networkName,
+		profileName,
+		accInterface,
+		instanceName,
+		acctest.TestImage,
+		subnet1.GatewayCIDRv4(),
+		subnet2.GatewayCIDRv4(),
+		subnet1.HostIPv4(200),
+		subnet2.HostIPv4(200),
+	)
 }
 
 func testAccInstance_target(name string, target string) string {
@@ -2635,13 +2652,13 @@ resource "lxd_instance" "instance1" {
 	`, name, acctest.TestImage, delay)
 }
 
-func testAccInstance_waitForIPv4(networkName, instanceName string) string {
+func testAccInstance_waitForIPv4(networkName, instanceName string, subnet acctest.Subnet) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network1" {
   name = "%s"
 
   config = {
-    "ipv4.address" = "10.150.18.1/24"
+    "ipv4.address" = "%s"
     "ipv6.address" = "none"
   }
 }
@@ -2666,21 +2683,21 @@ resource "lxd_instance" "instance1" {
     properties = {
       nictype        = "bridged"
       parent         = "${lxd_network.network1.name}"
-      "ipv4.address" = "10.150.18.200"
+      "ipv4.address" = "%s"
     }
   }
 }
-	`, networkName, instanceName, acctest.TestImage)
+	`, networkName, subnet.GatewayCIDRv4(), instanceName, acctest.TestImage, subnet.HostIPv4(200))
 }
 
-func testAccInstance_waitForIPv6(networkName, instanceName string) string {
+func testAccInstance_waitForIPv6(networkName, instanceName string, subnet acctest.Subnet) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network1" {
   name = "%s"
 
   config = {
     "ipv4.address" = "none"
-    "ipv6.address" = "fd42:1000:1000:1000::1/64"
+    "ipv6.address" = "%s"
   }
 }
 
@@ -2707,17 +2724,17 @@ resource "lxd_instance" "instance1" {
     }
   }
 }
-	`, networkName, instanceName, acctest.TestImage)
+	`, networkName, subnet.GatewayCIDRv6(), instanceName, acctest.TestImage)
 }
 
-func testAccInstance_waitForIPv4AndIPv6(networkName, instanceName string) string {
+func testAccInstance_waitForIPv4AndIPv6(networkName, instanceName string, subnet acctest.Subnet) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network1" {
   name = "%s"
 
   config = {
-    "ipv4.address" = "10.150.18.1/24"
-    "ipv6.address" = "fd42:1000:1000:1000::1/64"
+    "ipv4.address" = "%s"
+    "ipv6.address" = "%s"
   }
 }
 
@@ -2746,9 +2763,9 @@ resource "lxd_instance" "instance1" {
     properties = {
       nictype        = "bridged"
       parent         = "${lxd_network.network1.name}"
-      "ipv4.address" = "10.150.18.200"
+      "ipv4.address" = "%s"
     }
   }
 }
-	`, networkName, instanceName, acctest.TestImage)
+	`, networkName, subnet.GatewayCIDRv4(), subnet.GatewayCIDRv6(), instanceName, acctest.TestImage, subnet.HostIPv4(200))
 }

--- a/internal/network/resource_network_forward_test.go
+++ b/internal/network/resource_network_forward_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccNetworkForward_basic(t *testing.T) {
 	networkName := acctest.GenerateName(1, "")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -19,11 +20,11 @@ func TestAccNetworkForward_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkForward(networkName),
+				Config: acctest.Provider() + testAccNetworkForward(networkName, subnet),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("lxd_network_forward.forward", "listen_address", "10.150.19.10"),
+					resource.TestCheckResourceAttr("lxd_network_forward.forward", "listen_address", subnet.HostIPv4(10)),
 					resource.TestCheckResourceAttr("lxd_network_forward.forward", "description", "Network Forward"),
-					resource.TestCheckResourceAttr("lxd_network_forward.forward", "config.target_address", "10.150.19.111"),
+					resource.TestCheckResourceAttr("lxd_network_forward.forward", "config.target_address", subnet.HostIPv4(111)),
 				),
 			},
 		},
@@ -32,13 +33,14 @@ func TestAccNetworkForward_basic(t *testing.T) {
 
 func TestAccNetworkForward_Ports(t *testing.T) {
 	networkName := acctest.GenerateName(1, "")
+	subnet := acctest.GenerateSubnet()
 
 	entry1 := map[string]string{
 		"description":    "SSH",
 		"protocol":       "tcp",
 		"listen_port":    "22",
 		"target_port":    "2022",
-		"target_address": "10.150.19.112",
+		"target_address": subnet.HostIPv4(112),
 	}
 
 	entry2 := map[string]string{
@@ -46,7 +48,7 @@ func TestAccNetworkForward_Ports(t *testing.T) {
 		"protocol":       "tcp",
 		"listen_port":    "80",
 		"target_port":    "",
-		"target_address": "10.150.19.112",
+		"target_address": subnet.HostIPv4(112),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -57,11 +59,11 @@ func TestAccNetworkForward_Ports(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkForward_withPorts(networkName),
+				Config: acctest.Provider() + testAccNetworkForward_withPorts(networkName, subnet),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("lxd_network_forward.forward", "listen_address", "10.150.19.10"),
+					resource.TestCheckResourceAttr("lxd_network_forward.forward", "listen_address", subnet.HostIPv4(10)),
 					resource.TestCheckResourceAttr("lxd_network_forward.forward", "description", "Network Forward"),
-					resource.TestCheckResourceAttr("lxd_network_forward.forward", "config.target_address", "10.150.19.111"),
+					resource.TestCheckResourceAttr("lxd_network_forward.forward", "config.target_address", subnet.HostIPv4(111)),
 					resource.TestCheckTypeSetElemNestedAttrs("lxd_network_forward.forward", "ports.*", entry1),
 					resource.TestCheckTypeSetElemNestedAttrs("lxd_network_forward.forward", "ports.*", entry2),
 				),
@@ -70,15 +72,15 @@ func TestAccNetworkForward_Ports(t *testing.T) {
 	})
 }
 
-func testAccNetworkForward(networkName string) string {
+func testAccNetworkForward(networkName string, subnet acctest.Subnet) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "forward" {
   name = "%s"
 
   config = {
-    "ipv4.address" = "10.150.19.1/24"
+    "ipv4.address" = "%s"
     "ipv4.nat"     = "true"
-    "ipv6.address" = "fd42:474b:622d:259d::1/64"
+    "ipv6.address" = "%s"
     "ipv6.nat"     = "true"
   }
 }
@@ -86,24 +88,24 @@ resource "lxd_network" "forward" {
 resource "lxd_network_forward" "forward" {
   network        = lxd_network.forward.name
   description    = "Network Forward"
-  listen_address = "10.150.19.10"
+  listen_address = "%s"
 
   config = {
-    target_address = "10.150.19.111"
+    target_address = "%s"
   }
 }
-  `, networkName)
+  `, networkName, subnet.GatewayCIDRv4(), subnet.GatewayCIDRv6(), subnet.HostIPv4(10), subnet.HostIPv4(111))
 }
 
-func testAccNetworkForward_withPorts(networkName string) string {
+func testAccNetworkForward_withPorts(networkName string, subnet acctest.Subnet) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "forward" {
   name = "%s"
 
   config = {
-    "ipv4.address" = "10.150.19.1/24"
+    "ipv4.address" = "%s"
     "ipv4.nat"     = "true"
-    "ipv6.address" = "fd42:474b:622d:259d::1/64"
+    "ipv6.address" = "%s"
     "ipv6.nat"     = "true"
   }
 }
@@ -111,10 +113,10 @@ resource "lxd_network" "forward" {
 resource "lxd_network_forward" "forward" {
   network        = lxd_network.forward.name
   description    = "Network Forward"
-  listen_address = "10.150.19.10"
+  listen_address = "%s"
 
   config = {
-    target_address = "10.150.19.111"
+    target_address = "%s"
   }
 
   ports = [
@@ -123,15 +125,15 @@ resource "lxd_network_forward" "forward" {
       protocol       = "tcp"
       listen_port    = "22"
       target_port    = "2022"
-      target_address = "10.150.19.112"
+      target_address = "%[6]s"
     },
     {
       description    = "HTTP"
       protocol       = "tcp"
       listen_port    = "80"
-      target_address = "10.150.19.112"
+      target_address = "%[6]s"
     }
   ]
 }
-  `, networkName)
+  `, networkName, subnet.GatewayCIDRv4(), subnet.GatewayCIDRv6(), subnet.HostIPv4(10), subnet.HostIPv4(111), subnet.HostIPv4(112))
 }

--- a/internal/network/resource_network_lb_test.go
+++ b/internal/network/resource_network_lb_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccNetworkLB_basic(t *testing.T) {
+	uplinkSubnet := acctest.GenerateSubnet()
+	ovnSubnet := acctest.GenerateSubnet()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
@@ -19,16 +22,16 @@ func TestAccNetworkLB_basic(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkLB_basic(),
+				Config: acctest.Provider() + testAccNetworkLB_basic(uplinkSubnet, ovnSubnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.ovnbr", "name", "ovnbr"),
 					resource.TestCheckResourceAttr("lxd_network.ovnbr", "type", "bridge"),
 					resource.TestCheckResourceAttr("lxd_network.ovn", "name", "ovn"),
 					resource.TestCheckResourceAttr("lxd_network.ovn", "type", "ovn"),
-					resource.TestCheckResourceAttr("lxd_network.ovn", "config.ipv4.address", "10.0.0.1/24"),
-					resource.TestCheckResourceAttr("lxd_network.ovn", "config.ipv6.address", "fd42::1/64"),
+					resource.TestCheckResourceAttr("lxd_network.ovn", "config.ipv4.address", ovnSubnet.GatewayCIDRv4()),
+					resource.TestCheckResourceAttr("lxd_network.ovn", "config.ipv6.address", ovnSubnet.GatewayCIDRv6()),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "description", "Load Balancer"),
-					resource.TestCheckResourceAttr("lxd_network_lb.test", "listen_address", "10.10.10.200"),
+					resource.TestCheckResourceAttr("lxd_network_lb.test", "listen_address", uplinkSubnet.HostIPv4(200)),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "network", "ovn"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "config.%", "0"),
 				),
@@ -38,6 +41,9 @@ func TestAccNetworkLB_basic(t *testing.T) {
 }
 
 func TestAccNetworkLB_withConfig(t *testing.T) {
+	uplinkSubnet := acctest.GenerateSubnet()
+	ovnSubnet := acctest.GenerateSubnet()
+
 	lbConfig := map[string]string{
 		"user.test": "abcd",
 	}
@@ -50,12 +56,12 @@ func TestAccNetworkLB_withConfig(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkLB_withConfig(lbConfig),
+				Config: acctest.Provider() + testAccNetworkLB_withConfig(lbConfig, uplinkSubnet, ovnSubnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.ovnbr", "name", "ovnbr"),
 					resource.TestCheckResourceAttr("lxd_network.ovn", "name", "ovn"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "network", "ovn"),
-					resource.TestCheckResourceAttr("lxd_network_lb.test", "listen_address", "10.10.10.200"),
+					resource.TestCheckResourceAttr("lxd_network_lb.test", "listen_address", uplinkSubnet.HostIPv4(200)),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "config.%", "1"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "config.user.test", "abcd"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "port.#", "0"),
@@ -67,17 +73,19 @@ func TestAccNetworkLB_withConfig(t *testing.T) {
 }
 
 func TestAccNetworkLB_withBackendOnly(t *testing.T) {
+	uplinkSubnet := acctest.GenerateSubnet()
+	ovnSubnet := acctest.GenerateSubnet()
 	backendName := acctest.GenerateName(2, "-")
 
 	backend1 := api.NetworkLoadBalancerBackend{
 		Name:          backendName,
-		TargetAddress: "10.0.0.2",
+		TargetAddress: ovnSubnet.HostIPv4(2),
 		TargetPort:    "80",
 	}
 
 	backend2 := api.NetworkLoadBalancerBackend{
 		Name:          backendName,
-		TargetAddress: "10.0.0.2",
+		TargetAddress: ovnSubnet.HostIPv4(2),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -89,7 +97,7 @@ func TestAccNetworkLB_withBackendOnly(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkLB_withBackend(backend1),
+				Config: acctest.Provider() + testAccNetworkLB_withBackend(backend1, uplinkSubnet, ovnSubnet),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.PrintResourceState(t, "lxd_network_lb.test"),
 					resource.TestCheckResourceAttr("lxd_network.ovnbr", "name", "ovnbr"),
@@ -102,7 +110,7 @@ func TestAccNetworkLB_withBackendOnly(t *testing.T) {
 				),
 			},
 			{
-				Config: acctest.Provider() + testAccNetworkLB_withBackend(backend2),
+				Config: acctest.Provider() + testAccNetworkLB_withBackend(backend2, uplinkSubnet, ovnSubnet),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.PrintResourceState(t, "lxd_network_lb.test"),
 					resource.TestCheckResourceAttr("lxd_network.ovnbr", "name", "ovnbr"),
@@ -119,12 +127,14 @@ func TestAccNetworkLB_withBackendOnly(t *testing.T) {
 }
 
 func TestAccNetworkLB_withBackendAndPort(t *testing.T) {
+	uplinkSubnet := acctest.GenerateSubnet()
+	ovnSubnet := acctest.GenerateSubnet()
 	instanceName := acctest.GenerateName(2, "")
 
 	backend := api.NetworkLoadBalancerBackend{
 		Name:          "backend",
 		Description:   "Backend",
-		TargetAddress: "10.0.0.2",
+		TargetAddress: ovnSubnet.HostIPv4(2),
 		TargetPort:    "80",
 	}
 
@@ -142,12 +152,12 @@ func TestAccNetworkLB_withBackendAndPort(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkLB_withBackendAndPort(instanceName, backend, port),
+				Config: acctest.Provider() + testAccNetworkLB_withBackendAndPort(instanceName, backend, port, uplinkSubnet, ovnSubnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.ovnbr", "name", "ovnbr"),
 					resource.TestCheckResourceAttr("lxd_network.ovn", "name", "ovn"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "network", "ovn"),
-					resource.TestCheckResourceAttr("lxd_network_lb.test", "listen_address", "10.10.10.200"),
+					resource.TestCheckResourceAttr("lxd_network_lb.test", "listen_address", uplinkSubnet.HostIPv4(200)),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "backend.#", "1"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "backend.0.name", backend.Name),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "backend.0.description", backend.Description),
@@ -169,9 +179,12 @@ func TestAccNetworkLB_withBackendAndPort(t *testing.T) {
 }
 
 func TestAccNetworkLB_withBackendAndPort_noDescriptions(t *testing.T) {
+	uplinkSubnet := acctest.GenerateSubnet()
+	ovnSubnet := acctest.GenerateSubnet()
+
 	backend := api.NetworkLoadBalancerBackend{
 		Name:          "backend",
-		TargetAddress: "10.0.0.2",
+		TargetAddress: ovnSubnet.HostIPv4(2),
 		TargetPort:    "80",
 	}
 
@@ -188,7 +201,7 @@ func TestAccNetworkLB_withBackendAndPort_noDescriptions(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkLB_withBackendAndPort_noDescription(backend, port),
+				Config: acctest.Provider() + testAccNetworkLB_withBackendAndPort_noDescription(backend, port, uplinkSubnet, ovnSubnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.ovnbr", "name", "ovnbr"),
 					resource.TestCheckResourceAttr("lxd_network.ovn", "name", "ovn"),
@@ -204,9 +217,12 @@ func TestAccNetworkLB_withBackendAndPort_noDescriptions(t *testing.T) {
 }
 
 func TestAccNetworkLB_withBackendAndPort_noTargetPort(t *testing.T) {
+	uplinkSubnet := acctest.GenerateSubnet()
+	ovnSubnet := acctest.GenerateSubnet()
+
 	backend := api.NetworkLoadBalancerBackend{
 		Name:          "backend",
-		TargetAddress: "10.0.0.2",
+		TargetAddress: ovnSubnet.HostIPv4(2),
 	}
 
 	port := api.NetworkLoadBalancerPort{
@@ -223,7 +239,7 @@ func TestAccNetworkLB_withBackendAndPort_noTargetPort(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkLB_withBackendAndPort_noTargetPort(backend, port),
+				Config: acctest.Provider() + testAccNetworkLB_withBackendAndPort_noTargetPort(backend, port, uplinkSubnet, ovnSubnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.ovnbr", "name", "ovnbr"),
 					resource.TestCheckResourceAttr("lxd_network.ovn", "name", "ovn"),
@@ -231,7 +247,7 @@ func TestAccNetworkLB_withBackendAndPort_noTargetPort(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "backend.#", "1"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "backend.0.name", "backend"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "backend.0.description", ""),
-					resource.TestCheckResourceAttr("lxd_network_lb.test", "backend.0.target_address", "10.0.0.2"),
+					resource.TestCheckResourceAttr("lxd_network_lb.test", "backend.0.target_address", backend.TargetAddress),
 					resource.TestCheckNoResourceAttr("lxd_network_lb.test", "backend.0.target_port"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "port.#", "1"),
 					resource.TestCheckResourceAttr("lxd_network_lb.test", "port.0.description", ""),
@@ -244,19 +260,19 @@ func TestAccNetworkLB_withBackendAndPort_noTargetPort(t *testing.T) {
 	})
 }
 
-func testAccNetworkLB_basic() string {
-	lbRes := `
+func testAccNetworkLB_basic(uplinkSubnet acctest.Subnet, ovnSubnet acctest.Subnet) string {
+	lbRes := fmt.Sprintf(`
 resource "lxd_network_lb" "test" {
   network        = lxd_network.ovn.name
-  listen_address = "10.10.10.200"
+  listen_address = "%s"
   description    = "Load Balancer"
 }
-`
+`, uplinkSubnet.HostIPv4(200))
 
-	return fmt.Sprintf("%s\n%s", ovnNetworkResource(), lbRes)
+	return fmt.Sprintf("%s\n%s", ovnNetworkResource(uplinkSubnet, ovnSubnet), lbRes)
 }
 
-func testAccNetworkLB_withConfig(config map[string]string) string {
+func testAccNetworkLB_withConfig(config map[string]string, uplinkSubnet acctest.Subnet, ovnSubnet acctest.Subnet) string {
 	entries := strings.Builder{}
 	for k, v := range config {
 		entry := fmt.Sprintf("%q = %q\n", k, v)
@@ -266,57 +282,59 @@ func testAccNetworkLB_withConfig(config map[string]string) string {
 	lbRes := fmt.Sprintf(`
 resource "lxd_network_lb" "test" {
   network        = lxd_network.ovn.name
-  listen_address = "10.10.10.200"
+  listen_address = "%s"
   description    = "Load Balancer with Config"
 
   config = {
     %s
   }
 }
-`, entries.String())
+`, uplinkSubnet.HostIPv4(200), entries.String())
 
-	return fmt.Sprintf("%s\n%s", ovnNetworkResource(), lbRes)
+	return fmt.Sprintf("%s\n%s", ovnNetworkResource(uplinkSubnet, ovnSubnet), lbRes)
 }
 
-func testAccNetworkLB_withBackend(backend api.NetworkLoadBalancerBackend) string {
+func testAccNetworkLB_withBackend(backend api.NetworkLoadBalancerBackend, uplinkSubnet acctest.Subnet, ovnSubnet acctest.Subnet) string {
 	targetPort := ""
 	if backend.TargetPort != "" {
 		targetPort = fmt.Sprintf("target_port = %q", backend.TargetPort)
 	}
 
 	args := []any{
-		backend.Name,          // 1
-		backend.TargetAddress, // 2
-		targetPort,            // 3
+		uplinkSubnet.HostIPv4(200), // 1
+		backend.Name,               // 2
+		backend.TargetAddress,      // 3
+		targetPort,                 // 4
 	}
 
 	lbRes := fmt.Sprintf(`
 resource "lxd_network_lb" "test" {
   network        = lxd_network.ovn.name
-  listen_address = "10.10.10.200"
+  listen_address = "%[1]s"
 
   backend {
-    name           = "%[1]s"
-    target_address = "%[2]s"
-    %[3]s
+    name           = "%[2]s"
+    target_address = "%[3]s"
+    %[4]s
   }
 }
 `, args...)
 
-	return fmt.Sprintf("%s\n%s", ovnNetworkResource(), lbRes)
+	return fmt.Sprintf("%s\n%s", ovnNetworkResource(uplinkSubnet, ovnSubnet), lbRes)
 }
 
-func testAccNetworkLB_withBackendAndPort(instanceName string, backend api.NetworkLoadBalancerBackend, port api.NetworkLoadBalancerPort) string {
+func testAccNetworkLB_withBackendAndPort(instanceName string, backend api.NetworkLoadBalancerBackend, port api.NetworkLoadBalancerPort, uplinkSubnet acctest.Subnet, ovnSubnet acctest.Subnet) string {
 	args := []any{
-		instanceName,          // 1
-		acctest.TestImage,     // 2
-		backend.Name,          // 3
-		backend.Description,   // 4
-		backend.TargetAddress, // 5
-		backend.TargetPort,    // 6
-		port.Description,      // 7
-		port.Protocol,         // 8
-		port.ListenPort,       // 9
+		instanceName,               // 1
+		acctest.TestImage,          // 2
+		backend.Name,               // 3
+		backend.Description,        // 4
+		backend.TargetAddress,      // 5
+		backend.TargetPort,         // 6
+		port.Description,           // 7
+		port.Protocol,              // 8
+		port.ListenPort,            // 9
+		uplinkSubnet.HostIPv4(200), // 10
 	}
 
 	lbRes := fmt.Sprintf(`
@@ -337,7 +355,7 @@ resource "lxd_instance" "instance" {
 
 resource "lxd_network_lb" "test" {
   network        = lxd_network.ovn.name
-  listen_address = "10.10.10.200"
+  listen_address = "%[10]s"
   description    = "Load Balancer with Backend and Port"
 
   backend {
@@ -356,22 +374,23 @@ resource "lxd_network_lb" "test" {
 }
 `, args...)
 
-	return fmt.Sprintf("%s\n%s", ovnNetworkResource(), lbRes)
+	return fmt.Sprintf("%s\n%s", ovnNetworkResource(uplinkSubnet, ovnSubnet), lbRes)
 }
 
-func testAccNetworkLB_withBackendAndPort_noDescription(backend api.NetworkLoadBalancerBackend, port api.NetworkLoadBalancerPort) string {
+func testAccNetworkLB_withBackendAndPort_noDescription(backend api.NetworkLoadBalancerBackend, port api.NetworkLoadBalancerPort, uplinkSubnet acctest.Subnet, ovnSubnet acctest.Subnet) string {
 	args := []any{
-		backend.Name,          // 1
-		backend.TargetAddress, // 2
-		backend.TargetPort,    // 3
-		port.Protocol,         // 4
-		port.ListenPort,       // 5
+		backend.Name,               // 1
+		backend.TargetAddress,      // 2
+		backend.TargetPort,         // 3
+		port.Protocol,              // 4
+		port.ListenPort,            // 5
+		uplinkSubnet.HostIPv4(200), // 6
 	}
 
 	lbRes := fmt.Sprintf(`
 resource "lxd_network_lb" "test" {
   network        = lxd_network.ovn.name
-  listen_address = "10.10.10.200"
+  listen_address = "%[6]s"
   description    = "Load Balancer with Backend and Port"
 
   backend {
@@ -388,20 +407,21 @@ resource "lxd_network_lb" "test" {
 }
 `, args...)
 
-	return fmt.Sprintf("%s\n%s", ovnNetworkResource(), lbRes)
+	return fmt.Sprintf("%s\n%s", ovnNetworkResource(uplinkSubnet, ovnSubnet), lbRes)
 }
 
-func testAccNetworkLB_withBackendAndPort_noTargetPort(backend api.NetworkLoadBalancerBackend, port api.NetworkLoadBalancerPort) string {
+func testAccNetworkLB_withBackendAndPort_noTargetPort(backend api.NetworkLoadBalancerBackend, port api.NetworkLoadBalancerPort, uplinkSubnet acctest.Subnet, ovnSubnet acctest.Subnet) string {
 	args := []any{
-		backend.Name,          // 1
-		backend.TargetAddress, // 2
-		port.ListenPort,       // 3
+		backend.Name,               // 1
+		backend.TargetAddress,      // 2
+		port.ListenPort,            // 3
+		uplinkSubnet.HostIPv4(200), // 4
 	}
 
 	lbRes := fmt.Sprintf(`
 resource "lxd_network_lb" "test" {
   network        = lxd_network.ovn.name
-  listen_address = "10.10.10.200"
+  listen_address = "%[4]s"
 
   backend {
     name           = "%[1]s"
@@ -415,24 +435,23 @@ resource "lxd_network_lb" "test" {
 }
 `, args...)
 
-	return fmt.Sprintf("%s\n%s", ovnNetworkResource(), lbRes)
+	return fmt.Sprintf("%s\n%s", ovnNetworkResource(uplinkSubnet, ovnSubnet), lbRes)
 }
 
 // ovnNetworkPreset returns configuration for OVN network and its parent bridge.
-// Network resource "lxd_network.ovn" provides dhcp range "10.0.0.1/24".
-func ovnNetworkResource() string {
-	return `
+func ovnNetworkResource(uplinkSubnet acctest.Subnet, ovnSubnet acctest.Subnet) string {
+	return fmt.Sprintf(`
 resource "lxd_network" "ovnbr" {
   name = "ovnbr"
   type = "bridge"
   config = {
-    "ipv4.address"     = "10.10.10.1/24"
-    "ipv4.routes"      = "10.10.10.192/26"
-    "ipv4.ovn.ranges"  = "10.10.10.224-10.10.10.254"
-    "ipv4.dhcp.ranges" = "10.10.10.100-10.10.10.150"
-    "ipv6.address"     = "fd42:1000:1000:1000::1/64"
-    "ipv6.dhcp.ranges" = "fd42:1000:1000:1000:a::-fd42:1000:1000:1000:a::ffff"
-    "ipv6.ovn.ranges"  = "fd42:1000:1000:1000:b::-fd42:1000:1000:1000:b::ffff"
+    "ipv4.address"     = "%[1]s"
+    "ipv4.routes"      = "%[2]s/26"
+    "ipv4.ovn.ranges"  = "%[3]s"
+    "ipv4.dhcp.ranges" = "%[4]s"
+    "ipv6.address"     = "%[5]s"
+    "ipv6.dhcp.ranges" = "%[6]s"
+    "ipv6.ovn.ranges"  = "%[7]s"
   }
 }
 
@@ -441,11 +460,21 @@ resource "lxd_network" "ovn" {
   type = "ovn"
   config = {
     "network"      = lxd_network.ovnbr.name
-    "ipv4.address" = "10.0.0.1/24"
+    "ipv4.address" = "%[8]s"
     "ipv4.nat"     = "true"
-    "ipv6.address" = "fd42::1/64"
+    "ipv6.address" = "%[9]s"
     "ipv6.nat"     = "true"
   }
 }
-`
+`,
+		uplinkSubnet.GatewayCIDRv4(),
+		uplinkSubnet.HostIPv4(192),
+		uplinkSubnet.SubRangeV4(224, 254),
+		uplinkSubnet.SubRangeV4(100, 150),
+		uplinkSubnet.GatewayCIDRv6(),
+		uplinkSubnet.SubRangeV6(0xa),
+		uplinkSubnet.SubRangeV6(0xb),
+		ovnSubnet.GatewayCIDRv4(),
+		ovnSubnet.GatewayCIDRv6(),
+	)
 }

--- a/internal/network/resource_network_peer_test.go
+++ b/internal/network/resource_network_peer_test.go
@@ -11,13 +11,14 @@ import (
 func TestAccNetworkPeer_basic(t *testing.T) {
 	srcNetwork := acctest.GenerateName(2, "-")
 	dstNetwork := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkPeer_basic(srcNetwork, dstNetwork),
+				Config: acctest.Provider() + testAccNetworkPeer_basic(srcNetwork, dstNetwork, subnet),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.network_1", "name", srcNetwork),
 					resource.TestCheckResourceAttr("lxd_network.network_2", "name", dstNetwork),
@@ -43,13 +44,14 @@ func TestAccNetworkPeer_import(t *testing.T) {
 	resourceName := "lxd_network_peer.peer-1-2"
 	srcNetwork := acctest.GenerateName(2, "-")
 	dstNetwork := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetworkPeer_basic(srcNetwork, dstNetwork),
+				Config: acctest.Provider() + testAccNetworkPeer_basic(srcNetwork, dstNetwork, subnet),
 			},
 			{
 				ResourceName:  resourceName,
@@ -66,7 +68,7 @@ func TestAccNetworkPeer_import(t *testing.T) {
 	})
 }
 
-func testAccNetworkPeer_basic(srcNetwork string, dstNetwork string) string {
+func testAccNetworkPeer_basic(srcNetwork string, dstNetwork string, subnet acctest.Subnet) string {
 	peerRes := fmt.Sprintf(`
 resource "lxd_network" "network_1" {
   name = "%s"
@@ -99,25 +101,33 @@ resource "lxd_network_peer" "peer-2-1" {
 }
 `, srcNetwork, dstNetwork)
 
-	return fmt.Sprintf("%s\n%s", ovnUplinkNetworkResource(), peerRes)
+	return fmt.Sprintf("%s\n%s", ovnUplinkNetworkResource(subnet), peerRes)
 }
 
-// ovnNetworkPreset returns configuration for OVN network and its parent bridge.
-// Network resource "lxd_network.ovn" provides dhcp range "10.0.0.1/24".
-func ovnUplinkNetworkResource() string {
-	return `
+// ovnUplinkNetworkResource returns configuration for an OVN uplink bridge network.
+// Addressing (routes/DHCP/OVN ranges) is derived from the provided subnet.
+func ovnUplinkNetworkResource(subnet acctest.Subnet) string {
+	return fmt.Sprintf(`
 resource "lxd_network" "ovnbr" {
   name = "ovn_uplink"
   type = "bridge"
   config = {
-    "ipv4.address"     = "10.11.10.1/24"
-    "ipv4.routes"      = "10.11.10.192/26"
-    "ipv4.ovn.ranges"  = "10.11.10.193-10.11.10.254"
-    "ipv4.dhcp.ranges" = "10.11.10.100-10.11.10.150"
-    "ipv6.address"     = "fd42:1100:1000:1000::1/64"
-    "ipv6.dhcp.ranges" = "fd42:1100:1000:1000:a::-fd42:1100:1000:1000:a::ffff"
-    "ipv6.ovn.ranges"  = "fd42:1100:1000:1000:b::-fd42:1100:1000:1000:b::ffff"
+    "ipv4.address"     = "%s"
+    "ipv4.routes"      = "%s/26"
+    "ipv4.ovn.ranges"  = "%s"
+    "ipv4.dhcp.ranges" = "%s"
+    "ipv6.address"     = "%s"
+    "ipv6.dhcp.ranges" = "%s"
+    "ipv6.ovn.ranges"  = "%s"
   }
 }
-`
+`,
+		subnet.GatewayCIDRv4(),
+		subnet.HostIPv4(192),
+		subnet.SubRangeV4(193, 254),
+		subnet.SubRangeV4(100, 150),
+		subnet.GatewayCIDRv6(),
+		subnet.SubRangeV6(0xa),
+		subnet.SubRangeV6(0xb),
+	)
 }

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -49,6 +49,7 @@ func TestAccNetwork_basic(t *testing.T) {
 
 func TestAccNetwork_description(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -58,14 +59,14 @@ func TestAccNetwork_description(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetwork_desc(networkName),
+				Config: acctest.Provider() + testAccNetwork_desc(networkName, subnet.GatewayCIDRv4(), subnet.GatewayCIDRv6()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.network", "name", networkName),
 					resource.TestCheckResourceAttr("lxd_network.network", "type", "bridge"),
 					resource.TestCheckResourceAttr("lxd_network.network", "description", "My network"),
 					resource.TestCheckResourceAttr("lxd_network.network", "config.%", "2"),
-					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.address", "10.150.10.1/24"),
-					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv6.address", "fd42:474b:622d:259d::1/64"),
+					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.address", subnet.GatewayCIDRv4()),
+					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv6.address", subnet.GatewayCIDRv6()),
 				),
 			},
 		},
@@ -74,13 +75,14 @@ func TestAccNetwork_description(t *testing.T) {
 
 func TestAccNetwork_nullable(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetwork_nullable(networkName),
+				Config: acctest.Provider() + testAccNetwork_nullable(networkName, subnet.GatewayCIDRv4()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.network", "name", networkName),
 					resource.TestCheckResourceAttr("lxd_network.network", "type", "bridge"),
@@ -97,13 +99,14 @@ func TestAccNetwork_attach(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 	profileName := acctest.GenerateName(2, "-")
 	instanceName := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetwork_attach(networkName, profileName, instanceName),
+				Config: acctest.Provider() + testAccNetwork_attach(networkName, profileName, instanceName, subnet.GatewayCIDRv4()),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.network", "name", networkName),
 					resource.TestCheckResourceAttr("lxd_profile.profile1", "name", profileName),
@@ -129,15 +132,18 @@ func TestAccNetwork_updateConfig(t *testing.T) {
 	networkName := acctest.GenerateName(1, "-")
 	instanceName := acctest.GenerateName(2, "-")
 
+	subnet1 := acctest.GenerateSubnet()
+	subnet2 := acctest.GenerateSubnet()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetwork_updateConfig_1(networkName, instanceName),
+				Config: acctest.Provider() + testAccNetwork_updateConfig(networkName, subnet1.GatewayCIDRv4(), instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.network", "name", networkName),
-					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.address", "10.150.30.1/24"),
+					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.address", subnet1.GatewayCIDRv4()),
 					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.nat", "true"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
@@ -148,11 +154,11 @@ func TestAccNetwork_updateConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: acctest.Provider() + testAccNetwork_updateConfig_2(networkName, instanceName),
+				Config: acctest.Provider() + testAccNetwork_updateConfig(networkName, subnet2.GatewayCIDRv4(), instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_network.network", "name", networkName),
-					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.address", "10.150.40.1/24"),
-					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.nat", "false"),
+					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.address", subnet2.GatewayCIDRv4()),
+					resource.TestCheckResourceAttr("lxd_network.network", "config.ipv4.nat", "true"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "name", instanceName),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "status", "Running"),
 					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.#", "1"),
@@ -394,6 +400,7 @@ func TestAccNetwork_importBasic(t *testing.T) {
 func TestAccNetwork_importDesc(t *testing.T) {
 	resourceName := "lxd_network.network"
 	networkName := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -403,7 +410,7 @@ func TestAccNetwork_importDesc(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.Provider() + testAccNetwork_desc(networkName),
+				Config: acctest.Provider() + testAccNetwork_desc(networkName, subnet.GatewayCIDRv4(), subnet.GatewayCIDRv6()),
 			},
 			{
 				ResourceName:                         resourceName,
@@ -447,20 +454,20 @@ resource "lxd_network" "network" {
 `, networkName)
 }
 
-func testAccNetwork_desc(networkName string) string {
+func testAccNetwork_desc(networkName string, ipv4Address string, ipv6Address string) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network" {
   name        = "%s"
   description = "My network"
   config = {
-    "ipv4.address" = "10.150.10.1/24"
-    "ipv6.address" = "fd42:474b:622d:259d::1/64"
+    "ipv4.address" = "%s"
+    "ipv6.address" = "%s"
   }
 }
-`, networkName)
+`, networkName, ipv4Address, ipv6Address)
 }
 
-func testAccNetwork_nullable(networkName string) string {
+func testAccNetwork_nullable(networkName string, ipv4Address string) string {
 	return fmt.Sprintf(`
 locals {
   foo = "bar"
@@ -470,19 +477,19 @@ resource "lxd_network" "network" {
   name = "%s"
 
   config = {
-    "ipv4.address" = local.foo == "bar" ? null : "10.0.0.1/24"
+    "ipv4.address" = local.foo == "bar" ? null : "%s"
     "ipv6.address" = "none"
   }
 }
-`, networkName)
+`, networkName, ipv4Address)
 }
 
-func testAccNetwork_attach(networkName string, profileName string, instanceName string) string {
+func testAccNetwork_attach(networkName string, profileName string, instanceName string, ipv4Address string) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network" {
   name = "%s"
   config = {
-    "ipv4.address" = "10.150.20.1/24"
+    "ipv4.address" = "%s"
   }
 }
 
@@ -512,15 +519,15 @@ resource "lxd_instance" "instance1" {
     type = "ipv6"
   }
 }
-`, networkName, profileName, instanceName, acctest.TestImage)
+`, networkName, ipv4Address, profileName, instanceName, acctest.TestImage)
 }
 
-func testAccNetwork_updateConfig_1(networkName string, instanceName string) string {
+func testAccNetwork_updateConfig(networkName string, networkAddress string, instanceName string) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network" {
   name = "%s"
   config = {
-    "ipv4.address" = "10.150.30.1/24"
+    "ipv4.address" = "%s"
     "ipv4.nat"     = true
   }
 }
@@ -544,36 +551,7 @@ resource "lxd_instance" "instance1" {
     }
   }
 }
-`, networkName, instanceName, acctest.TestImage)
-}
-
-func testAccNetwork_updateConfig_2(networkName string, instanceName string) string {
-	return fmt.Sprintf(`
-resource "lxd_network" "network" {
-  name = "%s"
-
-  config = {
-    "ipv4.address" = "10.150.40.1/24"
-    "ipv4.nat"     = false
-  }
-}
-
-# We do need an instance here to ensure the network cannot
-# be deleted, but must be updated in-place.
-resource "lxd_instance" "instance1" {
-  name             = "%s"
-  image            = "%s"
-
-  device {
-    name = "eth0"
-    type = "nic"
-    properties = {
-      nictype = "bridged"
-      parent  = lxd_network.network.name
-    }
-  }
-}
-`, networkName, instanceName, acctest.TestImage)
+`, networkName, networkAddress, instanceName, acctest.TestImage)
 }
 
 func testAccNetwork_typeMacvlan(networkName string) string {


### PR DESCRIPTION
Fixes race condition in tests where same IP address was used.