### PR TITLE
Revert "github: stop using GPG signature for releases"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,17 @@ jobs:
           cache: false
           go-version-file: 'go.mod'
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+          passphrase: ${{ secrets.PASSPHRASE }} # zizmor: ignore[secrets-outside-env]
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           args: release --clean
         env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.1 (June 25, 2026)
+
+## What's Changed
+
+### Other Changes
+* Revert "github: stop using GPG signature for releases" by @MusicDin in https://github.com/terraform-lxd/terraform-provider-lxd/pull/746
+
 ## 3.0.0 (June 25, 2026)
 
 ## What's Changed


### PR DESCRIPTION
Revert GPG signing to ensure Terraform registry detects a new release.