### PR TITLE
Add Network ACL datasource

### DIFF
--- a/docs/data-sources/network_acl.md
+++ b/docs/data-sources/network_acl.md
@@ -1,0 +1,41 @@
+# lxd_network_acl
+
+Provides information about an existing LXD network ACL.
+
+## Example Usage
+
+```hcl
+data "lxd_network_acl" "acl" {
+  name = "my-acl"
+}
+```
+
+## Argument Reference
+
+* `name` - **Required** - Name of the network ACL.
+
+* `project` - *Optional* - Name of the project where the ACL is located.
+
+* `remote` - *Optional* - The remote in which the resource was created. If
+  not provided, the provider's default remote is used.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `description` - Description of the network ACL.
+
+* `config` - Map of key/value pairs of network ACL config settings.
+
+* `egress` - Set of egress rules. Each rule exports:
+  * `action` - Rule action (`allow`, `drop`, `reject`).
+  * `state` - Rule state (`enabled`, `disabled`, `logged`).
+  * `description` - Rule description.
+  * `source` - Source address/CIDR.
+  * `destination` - Destination address/CIDR.
+  * `destination_port` - Destination port(s).
+  * `protocol` - Protocol (`tcp`, `udp`, `icmp4`, `icmp6`).
+  * `icmp_type` - ICMP type (only relevant for icmp4/icmp6).
+  * `icmp_code` - ICMP code (only relevant for icmp4/icmp6).
+
+* `ingress` - Set of ingress rules. Same attributes as `egress`.

--- a/internal/network/datasource_network_acl.go
+++ b/internal/network/datasource_network_acl.go
@@ -1,0 +1,157 @@
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/common"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/errors"
+	provider_config "github.com/terraform-lxd/terraform-provider-lxd/internal/provider-config"
+)
+
+// NetworkAclDataSourceModel resource data model that matches the schema.
+type NetworkAclDataSourceModel struct {
+	Name        types.String `tfsdk:"name"`
+	Project     types.String `tfsdk:"project"`
+	Remote      types.String `tfsdk:"remote"`
+	Description types.String `tfsdk:"description"`
+	Config      types.Map    `tfsdk:"config"`
+	Egress      types.Set    `tfsdk:"egress"`
+	Ingress     types.Set    `tfsdk:"ingress"`
+}
+
+type NetworkAclDataSource struct {
+	provider *provider_config.LxdProviderConfig
+}
+
+func NewNetworkAclDataSource() datasource.DataSource {
+	return &NetworkAclDataSource{}
+}
+
+func (d *NetworkAclDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_network_acl", req.ProviderTypeName)
+}
+
+func (d *NetworkAclDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+
+			"project": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+
+			"remote": schema.StringAttribute{
+				Optional: true,
+			},
+
+			"description": schema.StringAttribute{
+				Computed: true,
+			},
+
+			"config": schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+
+			"egress": schema.SetNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: aclDatasourceRuleAttributes(),
+				},
+			},
+
+			"ingress": schema.SetNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: aclDatasourceRuleAttributes(),
+				},
+			},
+		},
+	}
+}
+
+func (d *NetworkAclDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.LxdProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+		return
+	}
+
+	d.provider = provider
+}
+
+func (d *NetworkAclDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state NetworkAclDataSourceModel
+
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	project := state.Project.ValueString()
+	server, err := d.provider.InstanceServer(remote, project, "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	aclName := state.Name.ValueString()
+	acl, _, err := server.GetNetworkACL(aclName)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve network ACL %q", aclName), err.Error())
+		return
+	}
+
+	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(acl.Config), state.Config)
+	resp.Diagnostics.Append(diags...)
+
+	egress, diags := ToNetworkAclRulesSetType(acl.Egress)
+	resp.Diagnostics.Append(diags...)
+
+	ingress, diags := ToNetworkAclRulesSetType(acl.Ingress)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state.Name = types.StringValue(acl.Name)
+	state.Description = types.StringValue(acl.Description)
+	state.Project = types.StringValue(acl.Project)
+	state.Config = config
+	state.Egress = egress
+	state.Ingress = ingress
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+// aclDatasourceRuleAttributes returns ACL rule attributes with all fields Computed,
+// for use in data source schemas where no validators or defaults are needed.
+func aclDatasourceRuleAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"action":           schema.StringAttribute{Computed: true},
+		"destination":      schema.StringAttribute{Computed: true},
+		"destination_port": schema.StringAttribute{Computed: true},
+		"protocol":         schema.StringAttribute{Computed: true},
+		"description":      schema.StringAttribute{Computed: true},
+		"state":            schema.StringAttribute{Computed: true},
+		"source":           schema.StringAttribute{Computed: true},
+		"icmp_type":        schema.StringAttribute{Computed: true},
+		"icmp_code":        schema.StringAttribute{Computed: true},
+	}
+}

--- a/internal/network/datasource_network_acl_test.go
+++ b/internal/network/datasource_network_acl_test.go
@@ -1,0 +1,136 @@
+package network_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
+)
+
+func TestAccNetworkACL_DS_basic(t *testing.T) {
+	aclName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccNetworkACL_DS_basic(aclName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.lxd_network_acl.acl", "name", aclName),
+					resource.TestCheckResourceAttr("data.lxd_network_acl.acl", "description", "Network ACL"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkACL_DS_withRules(t *testing.T) {
+	aclName := acctest.GenerateName(2, "-")
+
+	egressEntry := map[string]string{
+		"action":      "allow",
+		"destination": "1.1.1.1",
+		"protocol":    "udp",
+		"state":       "enabled",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccNetworkACL_DS_withRules(aclName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.lxd_network_acl.acl", "name", aclName),
+					resource.TestCheckResourceAttr("data.lxd_network_acl.acl", "egress.#", "1"),
+					resource.TestCheckResourceAttr("data.lxd_network_acl.acl", "ingress.#", "0"),
+					resource.TestCheckTypeSetElemNestedAttrs("data.lxd_network_acl.acl", "egress.*", egressEntry),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkACL_DS_withIngressRules(t *testing.T) {
+	aclName := acctest.GenerateName(2, "-")
+
+	ingressEntry := map[string]string{
+		"action":   "allow",
+		"source":   "@external",
+		"protocol": "tcp",
+		"state":    "enabled",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccNetworkACL_DS_withIngressRules(aclName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.lxd_network_acl.acl", "name", aclName),
+					resource.TestCheckResourceAttr("data.lxd_network_acl.acl", "egress.#", "0"),
+					resource.TestCheckResourceAttr("data.lxd_network_acl.acl", "ingress.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("data.lxd_network_acl.acl", "ingress.*", ingressEntry),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkACL_DS_basic(aclName string) string {
+	return fmt.Sprintf(`
+resource "lxd_network_acl" "acl" {
+  name        = %q
+  description = "Network ACL"
+}
+
+data "lxd_network_acl" "acl" {
+  name = lxd_network_acl.acl.name
+}
+`, aclName)
+}
+
+func testAccNetworkACL_DS_withRules(aclName string) string {
+	return fmt.Sprintf(`
+resource "lxd_network_acl" "acl" {
+  name = %q
+
+  egress = [
+    {
+      action      = "allow"
+      destination = "1.1.1.1"
+      protocol    = "udp"
+      state       = "enabled"
+    }
+  ]
+}
+
+data "lxd_network_acl" "acl" {
+  name = lxd_network_acl.acl.name
+}
+`, aclName)
+}
+
+func testAccNetworkACL_DS_withIngressRules(aclName string) string {
+	return fmt.Sprintf(`
+resource "lxd_network_acl" "acl" {
+  name = %q
+
+  ingress = [
+    {
+      action   = "allow"
+      source   = "@external"
+      protocol = "tcp"
+      state    = "enabled"
+    }
+  ]
+}
+
+data "lxd_network_acl" "acl" {
+  name = lxd_network_acl.acl.name
+}
+`, aclName)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -357,6 +357,7 @@ func (p *LxdProvider) DataSources(_ context.Context) []func() datasource.DataSou
 		image.NewImageDataSource,
 		instance.NewInstanceDataSource,
 		network.NewNetworkDataSource,
+		network.NewNetworkAclDataSource,
 		profile.NewProfileDataSource,
 		project.NewProjectDataSource,
 		server.NewInfoDataSource,


### PR DESCRIPTION
Closes #677.

Adds a `lxd_network_acl` data source so users can look up an existing network ACL by name and use its attributes (description, config, ingress/egress rules) elsewhere in their configuration.

```hcl
data "lxd_network_acl" "acl" {
  name = "my-acl"
}
```

Supports optional `project` and `remote` arguments, consistent with other data sources in this provider.
