### PR TITLE
auth: Allow creating pending TLS identities

### DIFF
--- a/docs/data-sources/auth_identity.md
+++ b/docs/data-sources/auth_identity.md
@@ -27,5 +27,8 @@ This data source exports the following attributes in addition to the arguments a
 * `groups` - List of group names the identity is part of.
 
 * `tls_certificate` - PEM encoded x509 certificate. Populated only for TLS identities.
+	It is empty for a pending TLS identity that has not yet redeemed its trust token.
 
-* `identifier` - Identity ID.
+* `identifier` - Identity ID. For a pending TLS identity this is a UUID, which LXD replaces
+	with the certificate fingerprint once the trust token is redeemed. Use `name` instead if
+	you need a value that is stable across that transition.

--- a/docs/resources/auth_identity.md
+++ b/docs/resources/auth_identity.md
@@ -21,6 +21,29 @@ resource "lxd_auth_identity" "tls-identity" {
 }
 ```
 
+### Pending TLS identity
+
+If `tls_certificate` is omitted for a `tls` identity, LXD creates the identity in a
+pending state and issues a trust token. The token is handed to an untrusted client,
+which redeems it to enroll its own certificate:
+
+```hcl
+resource "lxd_auth_identity" "pending-identity" {
+  auth_method = "tls"
+  name        = "jane"
+  groups      = ["admins"]
+}
+
+output "trust_token" {
+  value     = lxd_auth_identity.pending-identity.trust_token
+  sensitive = true
+}
+```
+
+The client then runs `lxc remote add <remote> <token>`.
+
+Requires the `access_management_tls` API extension.
+
 ## Argument Reference
 
 * `name` - **Required** - Name of the identity.
@@ -29,10 +52,41 @@ resource "lxd_auth_identity" "tls-identity" {
 
 * `groups` - *Optional* - List of group names to add this identity to.
 
-* `tls_certificate` - *Optional* - PEM encoded x509 certificate. Must be set when authentication method is `tls`.
+* `tls_certificate` - *Optional* - PEM encoded x509 certificate. Applicable only when the
+  authentication method is `tls`. If omitted, a pending TLS identity is created and a trust
+  token is issued instead. Once a TLS identity is created, removing this attribute from the
+  configuration leaves the certificate intact.
 
-* `remote` - *Optional* - The remote in which the resource will be created. If
-	not provided, the provider's default remote will be used.
+* `remote` - *Optional* - The remote in which the resource will be created. If not provided,
+  the provider's default remote will be used.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `trust_token` - Trust token that an untrusted client uses to enroll its certificate. It is
+  set only for a pending TLS identity, and is cleared once the token has been redeemed.
+
+* `expires_at` - Time at which the trust token expires, in RFC 3339 format and UTC. It is null when
+  the server config `core.remote_token_expiry` is not set, which means the token does not expire.
+
+## Pending TLS trust token lifecycle
+
+A trust token is returned only when a pending TLS identity is created, which means no
+`tls_certificate` was set, and can never be retrieved from the server afterwards. LXD
+provides no way to reissue a token for an existing identity, so if the token expires before
+it is redeemed, the identity is unusable and Terraform plans a replacement of the resource.
+
+Setting `tls_certificate` on a TLS identity whose token is still outstanding also plans a
+replacement. LXD does not allow a certificate to be set on a pending identity, and the
+outstanding token is invalidated along with the identity it was issued for.
+
+Once the token is redeemed, the identity holds a certificate and is never replaced on that
+account. Subsequent changes, such as group membership or a new `tls_certificate`, are
+applied in place.
+
+An imported pending TLS identity has no `trust_token`, because the token cannot be read back
+from the server.
 
 ## Importing
 

--- a/docs/resources/trust_token.md
+++ b/docs/resources/trust_token.md
@@ -1,6 +1,14 @@
 # lxd_trust_token
 
-The `lxd_trust_token` resource allows you to request a new trust token.
+The `lxd_trust_token` resource allows you to request a new legacy trust token.
+
+If the LXD server supports the `access_management_tls` API extension, use a
+[pending TLS identity](https://registry.terraform.io/providers/terraform-lxd/lxd/latest/docs/resources/auth_identity#pending-tls-identity)
+instead of the legacy trust token that this resource provides.
+
+~> **Warning:** Since LXD 5.21.5, client TLS identities must have unique names.
+  Once a TLS identity with a given name exists, the server rejects any token issued for that
+  name when it is consumed.
 
 ~> **Note:** The LXD trust token resource cannot be used for the initial authentication
   with the LXD server because LXD Terraform provider needs to be authenticated in order

--- a/internal/acctest/checks.go
+++ b/internal/acctest/checks.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -186,15 +187,23 @@ func PreCheckRoot(t *testing.T) {
 	}
 }
 
-// PreCheckLocalServerHTTPS skips the test if the server is not exposed on the localhost
-// over port 8443. This is required for remote provider tests.
-func PreCheckLocalServerHTTPS(t *testing.T) {
-	conn, err := net.DialTimeout("tcp", "127.0.0.1:8443", 1*time.Second)
+// PreCheckLocalServerHTTPS skips the test if the LXD server is not reachable over HTTPS.
+// Additionally, it returns the server's HTTPS address. If the test remote is a unix
+// socket, the local HTTPS address is used instead.
+func PreCheckLocalServerHTTPS(t *testing.T) string {
+	address := testRemotes()[testProviderRemoteName].Address
+	if strings.HasPrefix(address, "unix://") {
+		address = "https://127.0.0.1:8443"
+	}
+
+	conn, err := net.DialTimeout("tcp", strings.TrimPrefix(address, "https://"), 1*time.Second)
 	if err != nil {
-		t.Skip(`Skipping remote provider test. LXD is not available on "https://127.0.0.1:8443"`)
+		t.Skipf("Test %q skipped. LXD server is not available on %q.", t.Name(), address)
 	}
 
 	_ = conn.Close()
+
+	return address
 }
 
 // ConfigureTrustPassword sets and returns the trust password. If the server
@@ -303,6 +312,38 @@ func GenerateClientCertificate(t *testing.T) (clientCert string, clientKey strin
 	}
 
 	return clientCert, clientKey, cleanup
+}
+
+// RedeemTrustToken redeems a trust token that was issued for a pending TLS identity.
+// It connects to the LXD server as an untrusted client and enrolls the given client certificate,
+// which moves the identity out of the pending state.
+func RedeemTrustToken(t *testing.T, token string, clientCert string, clientKey string) {
+	// The token can only be redeemed on the server that issued it.
+	address := PreCheckLocalServerHTTPS(t)
+
+	// The client is not trusted yet, so the server certificate cannot be verified against a previously
+	// accepted fingerprint.
+	args := &lxd.ConnectionArgs{
+		TLSClientCert:      clientCert,
+		TLSClientKey:       clientKey,
+		InsecureSkipVerify: true,
+	}
+
+	untrustedServer, err := lxd.ConnectLXD(address, args)
+	if err != nil {
+		t.Fatalf("Failed to connect to LXD server as an untrusted client: %v", err)
+	}
+
+	// Only the trust token may be provided.
+	// LXD enrolls the client certificate that was presented during the TLS handshake.
+	identityPost := api.IdentitiesTLSPost{
+		TrustToken: token,
+	}
+
+	err = untrustedServer.CreateIdentityTLS(identityPost)
+	if err != nil {
+		t.Fatalf("Failed to redeem trust token: %v", err)
+	}
 }
 
 // ConfigureMutualTLS generates a new client certificate and key, adds the

--- a/internal/auth/datasource_identity_test.go
+++ b/internal/auth/datasource_identity_test.go
@@ -24,6 +24,7 @@ func TestAccIdentity_DS_bearer(t *testing.T) {
 					resource.TestCheckResourceAttr("data.lxd_auth_identity.identity", "name", identity),
 					resource.TestCheckResourceAttr("data.lxd_auth_identity.identity", "auth_method", "bearer"),
 					resource.TestCheckResourceAttr("data.lxd_auth_identity.identity", "groups.#", "0"),
+					resource.TestCheckResourceAttrSet("data.lxd_auth_identity.identity", "identifier"),
 				),
 			},
 			{
@@ -64,6 +65,7 @@ func TestAccIdentity_DS_tls(t *testing.T) {
 					resource.TestCheckResourceAttr("data.lxd_auth_identity.identity", "auth_method", "tls"),
 					resource.TestCheckResourceAttr("data.lxd_auth_identity.identity", "groups.#", "0"),
 					resource.TestCheckResourceAttrSet("data.lxd_auth_identity.identity", "tls_certificate"),
+					resource.TestCheckResourceAttrSet("data.lxd_auth_identity.identity", "identifier"),
 				),
 			},
 			{
@@ -79,6 +81,41 @@ func TestAccIdentity_DS_tls(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccIdentity_DS_tlsPending(t *testing.T) {
+	identity := acctest.GenerateName(2, "-")
+	dataSourceName := "data.lxd_auth_identity.identity"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "access_management", "access_management_tls")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// A pending identity has no certificate, and its identifier is a UUID that LXD replaces with
+				// the certificate fingerprint once the trust token is redeemed.
+				Config: acctest.Provider() + testAccIdentity_DS_tlsPending(identity),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", identity),
+					resource.TestCheckResourceAttr(dataSourceName, "auth_method", "tls"),
+					resource.TestCheckResourceAttr(dataSourceName, "tls_certificate", ""),
+					resource.TestCheckResourceAttrSet(dataSourceName, "identifier"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentity_DS_tlsPending(name string) string {
+	return testAccIdentity_tlsPending(name, []string{}) + `
+		data "lxd_auth_identity" "identity" {
+		  auth_method = "tls"
+		  name        = lxd_auth_identity.identity.name
+		}
+	`
 }
 
 func testAccIdentity_DS_bearer(name string, groups []string) string {

--- a/internal/auth/resource_identity.go
+++ b/internal/auth/resource_identity.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -29,6 +30,10 @@ type AuthIdentityModel struct {
 	AuthMethod  types.String `tfsdk:"auth_method"`
 	Certificate types.String `tfsdk:"tls_certificate"`
 	Remote      types.String `tfsdk:"remote"`
+
+	// Computed.
+	TrustToken types.String `tfsdk:"trust_token"`
+	ExpiresAt  types.String `tfsdk:"expires_at"`
 }
 
 // AuthIdentityResource manages LXD identity entries.
@@ -72,13 +77,30 @@ func (r AuthIdentityResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 			},
 
+			// Computed, because a pending TLS identity receives its certificate when an untrusted client
+			// redeems the issued trust token.
 			"tls_certificate": schema.StringAttribute{
 				Optional:  true,
+				Computed:  true,
 				Sensitive: true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 
 			"remote": schema.StringAttribute{
 				Optional: true,
+			},
+
+			// Computed.
+
+			"trust_token": schema.StringAttribute{
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"expires_at": schema.StringAttribute{
+				Computed: true,
 			},
 		},
 	}
@@ -123,17 +145,52 @@ func (r AuthIdentityResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// Whether the certificate is set must be determined from the configuration, because the
+	// attribute is computed and therefore indistinguishable from an empty value in the plan.
+	var configTLSCertificate types.String
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("tls_certificate"), &configTLSCertificate)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	hasTLSCertificate := !configTLSCertificate.IsNull()
+
+	// A trust token is issued only when creating a pending TLS identity.
+	plan.TrustToken = types.StringNull()
+	plan.ExpiresAt = types.StringNull()
+
 	switch identityAuthMethod {
 	case "tls":
-		req := api.IdentitiesTLSPost{
-			Name:        identityName,
-			Groups:      identityGroupNames,
-			Certificate: identityTLSCertificate,
-		}
+		if hasTLSCertificate {
+			req := api.IdentitiesTLSPost{
+				Name:        identityName,
+				Groups:      identityGroupNames,
+				Certificate: identityTLSCertificate,
+			}
 
-		err = server.CreateIdentityTLS(req)
+			err = server.CreateIdentityTLS(req)
+		} else {
+			// Without a certificate, LXD creates the identity in a pending state and issues a trust token.
+			// The token is returned only here and can never be retrieved from the server afterwards.
+			// An untrusted client redeems it to enroll its own certificate, which moves the identity out of
+			// the pending state.
+			req := api.IdentitiesTLSPost{
+				Name:   identityName,
+				Groups: identityGroupNames,
+				Token:  true,
+			}
+
+			var token *api.CertificateAddToken
+
+			token, err = server.CreateIdentityTLSToken(req)
+			if err == nil {
+				plan.TrustToken = types.StringValue(token.String())
+				plan.ExpiresAt = tokenExpiry(token.ExpiresAt)
+			}
+		}
 	case "bearer":
-		if identityTLSCertificate != "" {
+		if hasTLSCertificate {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Invalid %q identity %q", identityName, identityAuthMethod),
 				"Certificate must not be set for identities with authentication method bearer",
@@ -216,10 +273,26 @@ func (r AuthIdentityResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	_, etag, err := server.GetIdentity(identityAuthMethod, identityName)
+	// Whether the certificate is set must be determined from the configuration, because the
+	// attribute is computed and therefore indistinguishable from an empty value in the plan.
+	var configTLSCertificate types.String
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("tls_certificate"), &configTLSCertificate)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	identity, etag, err := server.GetIdentity(identityAuthMethod, identityName)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve existing %q identity %q", identityAuthMethod, identityName), err.Error())
 		return
+	}
+
+	if configTLSCertificate.IsNull() {
+		// Carry over the certificate that is stored on the server.
+		// Without this, an update that touches only the groups would clear the certificate of an identity
+		// that obtained it by redeeming a trust token.
+		identityTLSCertificate = identity.TLSCertificate
 	}
 
 	identityUpdateReq := api.IdentityPut{
@@ -232,6 +305,13 @@ func (r AuthIdentityResource) Update(ctx context.Context, req resource.UpdateReq
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update %q identity %q", identityAuthMethod, identityName), err.Error())
 		return
 	}
+
+	// The trust token is returned only on creation and cannot be retrieved from the server, so the
+	// prior state holds the only copy.
+	// Both attributes are computed and therefore unknown in the plan, which would discard the token
+	// of an identity that is still pending.
+	plan.TrustToken = state.TrustToken
+	plan.ExpiresAt = state.ExpiresAt
 
 	diags := r.SyncState(ctx, &resp.State, server, plan, false)
 	resp.Diagnostics.Append(diags...)
@@ -261,6 +341,54 @@ func (r AuthIdentityResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 }
 
+// ModifyPlan forces replacement of a pending TLS identity in two cases: its trust token has
+// expired, or a certificate has been configured for it.
+// LXD has no endpoint to reissue a token for an existing identity, and it refuses to set a
+// certificate on an identity that is still pending.
+// Either way the only way forward is to delete the identity and create it again.
+func (r AuthIdentityResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Skip on create (no prior state) and destroy (no plan).
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var state AuthIdentityModel
+	var config AuthIdentityModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// A pending identity is the only TLS identity that LXD reports without a certificate.
+	isPending := state.AuthMethod.ValueString() == "tls" && state.Certificate.IsNull()
+
+	// The attribute that is reported as forcing the replacement.
+	var replaceOn path.Path
+
+	switch {
+	case isTrustTokenExpired(isPending, state.ExpiresAt, time.Now()):
+		replaceOn = path.Root("trust_token")
+		resp.Diagnostics.AddWarning(
+			"Trust token expired",
+			fmt.Sprintf("The trust token for pending TLS identity %q has expired, so Terraform must replace the identity to issue a new token.", state.Name.ValueString()),
+		)
+	case isCertificateSetOnPending(isPending, config.Certificate):
+		replaceOn = path.Root("tls_certificate")
+	default:
+		return
+	}
+
+	// The replacement is created from scratch, so no computed attribute can be carried over from the
+	// prior state.
+	// An identity created with a certificate is active and has no trust token, one created without is
+	// pending and has a new one, and neither is known before apply.
+	resp.RequiresReplace = append(resp.RequiresReplace, replaceOn)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("trust_token"), types.StringUnknown())...)
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("expires_at"), types.StringUnknown())...)
+}
+
 // TaintState marks the state with identity fields required to target the identity.
 func (m AuthIdentityModel) TaintState(ctx context.Context, tfState *tfsdk.State) diag.Diagnostics {
 	var diags diag.Diagnostics
@@ -268,6 +396,11 @@ func (m AuthIdentityModel) TaintState(ctx context.Context, tfState *tfsdk.State)
 	diags.Append(tfState.SetAttribute(ctx, path.Root("name"), m.Name.ValueString())...)
 	diags.Append(tfState.SetAttribute(ctx, path.Root("auth_method"), m.AuthMethod.ValueString())...)
 	diags.Append(tfState.SetAttribute(ctx, path.Root("remote"), m.Remote.ValueString())...)
+
+	// The trust token is returned only on creation and cannot be retrieved from the server.
+	// Persist it before the remaining state is synced, so that it is not lost if syncing fails.
+	diags.Append(tfState.SetAttribute(ctx, path.Root("trust_token"), m.TrustToken)...)
+	diags.Append(tfState.SetAttribute(ctx, path.Root("expires_at"), m.ExpiresAt)...)
 
 	return diags
 }
@@ -291,8 +424,19 @@ func (r AuthIdentityResource) SyncState(ctx context.Context, tfState *tfsdk.Stat
 
 	m.Name = types.StringValue(identity.Name)
 	m.AuthMethod = types.StringValue(identityAuthMethod)
+
 	if identity.TLSCertificate != "" {
 		m.Certificate = types.StringValue(identity.TLSCertificate)
+	} else {
+		m.Certificate = types.StringNull()
+	}
+
+	// The trust token is single use.
+	// Once the identity leaves the pending state the token has been consumed and no longer refers to
+	// anything.
+	if identity.Type != api.IdentityTypeCertificateClientPending {
+		m.TrustToken = types.StringNull()
+		m.ExpiresAt = types.StringNull()
 	}
 
 	groups, diags := common.ToStringSetType(ctx, identity.Groups)
@@ -331,4 +475,55 @@ func (r *AuthIdentityResource) ImportState(ctx context.Context, req resource.Imp
 
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(k), v)...)
 	}
+}
+
+// tokenExpiry converts a trust token expiry into a Terraform value.
+// LXD returns a zero time when core.remote_token_expiry is disabled, which means the issued token
+// does not expire.
+func tokenExpiry(expiresAt time.Time) types.String {
+	if expiresAt.IsZero() {
+		return types.StringNull()
+	}
+
+	return types.StringValue(expiresAt.UTC().Format(time.RFC3339))
+}
+
+// isTrustTokenExpired reports whether an identity is still pending and its trust token can no
+// longer be redeemed.
+// Such an identity is unusable, and because LXD cannot reissue a token, it has to be replaced.
+func isTrustTokenExpired(isPending bool, expiresAt types.String, now time.Time) bool {
+	if !isPending {
+		return false
+	}
+
+	// A token without an expiry remains valid indefinitely.
+	if expiresAt.IsNull() || expiresAt.IsUnknown() {
+		return false
+	}
+
+	parsed, err := time.Parse(time.RFC3339, expiresAt.ValueString())
+	if err != nil {
+		return false
+	}
+
+	return now.After(parsed)
+}
+
+// isCertificateSetOnPending reports whether a certificate is configured for an identity that is
+// still pending.
+// LXD rejects such an update, so the identity has to be replaced, which also invalidates the
+// outstanding trust token.
+//
+// The certificate is taken from the configuration rather than the plan.
+// While the identity is pending its certificate is null in state, and because the attribute is
+// computed the framework marks it unknown in the plan whether or not one was configured, which
+// makes the two cases indistinguishable there.
+func isCertificateSetOnPending(isPending bool, configCertificate types.String) bool {
+	if !isPending {
+		return false
+	}
+
+	// An unknown certificate is one that is configured but not yet computed.
+	// It still means the identity is about to receive one.
+	return !configCertificate.IsNull()
 }

--- a/internal/auth/resource_identity_internal_test.go
+++ b/internal/auth/resource_identity_internal_test.go
@@ -1,0 +1,111 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenExpiry(t *testing.T) {
+	// LXD returns a zero time when core.remote_token_expiry is disabled.
+	require.True(t, tokenExpiry(time.Time{}).IsNull())
+
+	expiresAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	require.Equal(t, "2026-07-30T12:00:00Z", tokenExpiry(expiresAt).ValueString())
+}
+
+func TestIsTrustTokenExpired(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	past := types.StringValue(now.Add(-time.Minute).Format(time.RFC3339))
+	future := types.StringValue(now.Add(time.Minute).Format(time.RFC3339))
+
+	tests := []struct {
+		name      string
+		isPending bool
+		expiresAt types.String
+		expected  bool
+	}{
+		{
+			name:      "pending identity with an expired token",
+			isPending: true,
+			expiresAt: past,
+			expected:  true,
+		},
+		{
+			name:      "pending identity with a valid token",
+			isPending: true,
+			expiresAt: future,
+			expected:  false,
+		},
+		{
+			name:      "pending identity with a token that never expires",
+			isPending: true,
+			expiresAt: types.StringNull(),
+			expected:  false,
+		},
+		{
+			name:      "pending identity with an unparsable expiry",
+			isPending: true,
+			expiresAt: types.StringValue("2026/07/30 12:00 UTC"),
+			expected:  false,
+		},
+		{
+			name:      "redeemed identity keeps a stale expiry",
+			isPending: false,
+			expiresAt: past,
+			expected:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.expected, isTrustTokenExpired(test.isPending, test.expiresAt, now))
+		})
+	}
+}
+
+func TestIsCertificateSetOnPending(t *testing.T) {
+	certificate := types.StringValue("-----BEGIN CERTIFICATE-----")
+
+	tests := []struct {
+		name              string
+		isPending         bool
+		configCertificate types.String
+		expected          bool
+	}{
+		{
+			name:              "pending identity with a configured certificate",
+			isPending:         true,
+			configCertificate: certificate,
+			expected:          true,
+		},
+		{
+			name:              "pending identity with a certificate that is not yet computed",
+			isPending:         true,
+			configCertificate: types.StringUnknown(),
+			expected:          true,
+		},
+		{
+			name:              "pending identity without a configured certificate",
+			isPending:         true,
+			configCertificate: types.StringNull(),
+			expected:          false,
+		},
+		{
+			name:              "redeemed identity rotating its certificate",
+			isPending:         false,
+			configCertificate: certificate,
+			expected:          false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.expected, isCertificateSetOnPending(test.isPending, test.configCertificate))
+		})
+	}
+}

--- a/internal/auth/resource_identity_test.go
+++ b/internal/auth/resource_identity_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
@@ -82,6 +84,119 @@ func TestAccIdentity_tls(t *testing.T) {
 	})
 }
 
+func TestAccIdentity_tlsPending(t *testing.T) {
+	identity := acctest.GenerateName(2, "-")
+	resourceName := "lxd_auth_identity.identity"
+
+	clientCert, clientKey, cleanupCert := acctest.GenerateClientCertificate(t)
+	defer cleanupCert()
+
+	var token string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "access_management", "access_management_tls")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Omitting the certificate creates a pending identity and issues a trust token.
+				Config: acctest.Provider() + testAccIdentity_tlsPending(identity, []string{"admins"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", identity),
+					resource.TestCheckResourceAttr(resourceName, "auth_method", "tls"),
+					resource.TestCheckResourceAttr(resourceName, "groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "groups.0", "admins"),
+					resource.TestCheckNoResourceAttr(resourceName, "tls_certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "trust_token"),
+					testAccIdentity_captureAttr(resourceName, "trust_token", &token),
+				),
+			},
+			{
+				// Updating an identity that is still pending must preserve its trust token, which is
+				// issued once and cannot be retrieved from the server.
+				Config: acctest.Provider() + testAccIdentity_tlsPending(identity, []string{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "groups.#", "0"),
+					resource.TestCheckResourceAttrPtr(resourceName, "trust_token", &token),
+				),
+			},
+			{
+				// Redeeming the token enrolls the client certificate, which moves the identity out of the
+				// pending state.
+				// The consumed token is cleared and the identity must converge without producing a diff.
+				PreConfig: func() {
+					acctest.RedeemTrustToken(t, token, clientCert, clientKey)
+				},
+				Config: acctest.Provider() + testAccIdentity_tlsPending(identity, []string{"admins"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", identity),
+					resource.TestCheckResourceAttr(resourceName, "groups.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "tls_certificate"),
+					resource.TestCheckNoResourceAttr(resourceName, "trust_token"),
+					resource.TestCheckNoResourceAttr(resourceName, "expires_at"),
+				),
+			},
+			{
+				// Updating a redeemed identity must not clear its certificate.
+				Config: acctest.Provider() + testAccIdentity_tlsPending(identity, []string{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", identity),
+					resource.TestCheckResourceAttr(resourceName, "groups.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "tls_certificate"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentity_tlsPendingCertificate(t *testing.T) {
+	identity := acctest.GenerateName(2, "-")
+	resourceName := "lxd_auth_identity.identity"
+
+	clientCert, _, cleanupCert := acctest.GenerateClientCertificate(t)
+	defer cleanupCert()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "access_management", "access_management_tls")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Omitting the certificate creates a pending identity and issues a trust token.
+				Config: acctest.Provider() + testAccIdentity_tlsPending(identity, []string{"admins"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", identity),
+					resource.TestCheckNoResourceAttr(resourceName, "tls_certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "trust_token"),
+				),
+			},
+			{
+				// LXD refuses a certificate on an identity that is still pending, so configuring one replaces
+				// the identity instead of updating it.
+				// The outstanding trust token is invalidated along with the old identity, and the replacement
+				// is active from the start.
+				Config: acctest.Provider() + testAccIdentity_tlsPendingWithCertificate(identity, []string{"admins"}, clientCert),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", identity),
+					resource.TestCheckResourceAttr(resourceName, "groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tls_certificate", clientCert),
+					resource.TestCheckNoResourceAttr(resourceName, "trust_token"),
+					resource.TestCheckNoResourceAttr(resourceName, "expires_at"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIdentity_importEmpty(t *testing.T) {
 	resourceName := "lxd_auth_identity.identity"
 
@@ -146,6 +261,55 @@ func testAccIdentity_bearer(name string, groups []string) string {
         `,
 		name,
 		acctest.QuoteStrings(groups),
+	)
+}
+
+// testAccIdentity_captureAttr stores the value of the given resource attribute in target, so that
+// it can be used by a subsequent test step.
+func testAccIdentity_captureAttr(resourceName string, attrName string, target *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		res, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource %q not found", resourceName)
+		}
+
+		value, ok := res.Primary.Attributes[attrName]
+		if !ok {
+			return fmt.Errorf("Attribute %q not found in resource %q", attrName, resourceName)
+		}
+
+		*target = value
+
+		return nil
+	}
+}
+
+func testAccIdentity_tlsPending(name string, groups []string) string {
+	return fmt.Sprintf(`
+		resource "lxd_auth_identity" "identity" {
+		  auth_method = "tls"
+		  name        = %q
+		  groups      = [%s]
+		}
+	`,
+		name,
+		acctest.QuoteStrings(groups),
+	)
+}
+
+func testAccIdentity_tlsPendingWithCertificate(name string, groups []string, certificate string) string {
+	return fmt.Sprintf(`
+		resource "lxd_auth_identity" "identity" {
+		  auth_method = "tls"
+		  name        = %q
+		  groups      = [%s]
+
+		  tls_certificate = %q
+		}
+	`,
+		name,
+		acctest.QuoteStrings(groups),
+		certificate,
 	)
 }
 


### PR DESCRIPTION
The `lxd_auth_identity` field `tls_certificate` is now optional. If it is not set, LXD creates a pending identity and returns a trust_token (set as computed field). Other client can use the trust token to enroll its own certificate.

The trust token is stored in state because once the identity is created, LXD cannot reissue it. If it expires before it is redeemed, the identity is replaced. It is also replaced if `tls_certificate` is set while the identity is pending.

Once the token is consumed, the identity becomes a regular TLS identity. There is no plan diff, and later changes, including a new certificate, are updated in place.

Requires the `access_management_tls` API extension.