### PR TITLE
network: fix ModifyPlan failing on unknown config values

### DIFF
--- a/internal/common/lxd_config.go
+++ b/internal/common/lxd_config.go
@@ -38,6 +38,24 @@ func ToConfigMap(ctx context.Context, configMap types.Map) (map[string]string, d
 	return config, nil
 }
 
+// ConfigHasUnknownValue reports whether configMap, or any value within it,
+// is not yet known. A map can be fully known while still containing
+// individual unknown values (e.g. a value sourced from a resource that has
+// not been applied yet), which ToConfigMap cannot convert.
+func ConfigHasUnknownValue(configMap types.Map) bool {
+	if configMap.IsUnknown() {
+		return true
+	}
+
+	for _, v := range configMap.Elements() {
+		if v.IsUnknown() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ToConfigMapType converts map[string]string into config of type types.Map.
 func ToConfigMapType(ctx context.Context, config map[string]*string, modelConfig types.Map) (types.Map, diag.Diagnostics) {
 	// Add any missing nil values.

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -176,6 +176,31 @@ func (r *NetworkResource) Configure(_ context.Context, req resource.ConfigureReq
 	r.provider = provider
 }
 
+// memberOverridesHaveUnknownConfig reports whether any entry of an otherwise
+// known member_overrides map contains a config value that is only known
+// after apply. The outer map can be fully known (all member keys present)
+// while a nested override's "config" attribute, or a value within it,
+// remains unknown, which ToConfigMap cannot convert.
+func memberOverridesHaveUnknownConfig(ctx context.Context, memberOverrides types.Map) bool {
+	if memberOverrides.IsNull() || memberOverrides.IsUnknown() {
+		return false
+	}
+
+	overrides := map[string]NetworkMemberModel{}
+	diags := memberOverrides.ElementsAs(ctx, &overrides, true)
+	if diags.HasError() {
+		return false
+	}
+
+	for _, override := range overrides {
+		if common.ConfigHasUnknownValue(override.Config) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (r *NetworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		// Nothing to do on destroy.
@@ -190,9 +215,10 @@ func (r *NetworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 	}
 
 	// Cannot expand members if type or member_overrides are not yet known,
-	// or if config contains a value that is only known after apply (e.g.
-	// sourced from a resource applied later in the same plan).
-	if plan.Type.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) {
+	// or if config (global or within a member override) contains a value
+	// that is only known after apply (e.g. sourced from a resource applied
+	// later in the same plan).
+	if plan.Type.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || memberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
 		return
 	}
 

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -189,8 +189,10 @@ func (r *NetworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		return
 	}
 
-	// Cannot expand members if type or member_overrides are not yet known.
-	if plan.Type.IsUnknown() || plan.MemberOverrides.IsUnknown() {
+	// Cannot expand members if type or member_overrides are not yet known,
+	// or if config contains a value that is only known after apply (e.g.
+	// sourced from a resource applied later in the same plan).
+	if plan.Type.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) {
 		return
 	}
 

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -47,6 +47,29 @@ func TestAccNetwork_basic(t *testing.T) {
 	})
 }
 
+// TestAccNetwork_unknownConfigValue verifies that a network can be created
+// with a config value that is only known after apply (e.g. sourced from
+// another resource applied in the same plan). Regression test for the
+// ModifyPlan config parsing failing on unknown values within an otherwise
+// known config map.
+func TestAccNetwork_unknownConfigValue(t *testing.T) {
+	networkName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccNetwork_unknownConfigValue(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_network.network", "name", networkName),
+					resource.TestCheckResourceAttrWith("lxd_network.network", "config.ipv4.address", isCIDR),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetwork_description(t *testing.T) {
 	networkName := acctest.GenerateName(2, "-")
 	subnet := acctest.GenerateSubnet()
@@ -453,6 +476,28 @@ func testAccNetwork_basic(networkName string) string {
 	return fmt.Sprintf(`
 resource "lxd_network" "network" {
   name = "%s"
+}
+`, networkName)
+}
+
+func testAccNetwork_unknownConfigValue(networkName string) string {
+	return fmt.Sprintf(`
+resource "terraform_data" "unknown_value" {}
+
+locals {
+  # A value only known after apply (terraform_data.id is a random UUID
+  # assigned on create), simulating e.g. an externally allocated subnet
+  # resolved via a depends_on chain.
+  unknown_octet = parseint(substr(replace(terraform_data.unknown_value.id, "-", ""), 0, 1), 16)
+}
+
+resource "lxd_network" "network" {
+  name = "%s"
+  type = "bridge"
+
+  config = {
+    "ipv4.address" = "10.201.${local.unknown_octet}.1/24"
+  }
 }
 `, networkName)
 }

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -724,8 +724,10 @@ resource "terraform_data" "unknown_value" {}
 locals {
   # A value only known after apply (terraform_data.id is a random UUID
   # assigned on create), nested within member_overrides, simulating e.g. an
-  # externally allocated value resolved via a depends_on chain.
-  unknown_suffix = substr(replace(terraform_data.unknown_value.id, "-", ""), 0, 6)
+  # externally allocated value resolved via a depends_on chain. Kept short
+  # since the resulting string is used as a Linux interface name, which is
+  # limited to 15 characters.
+  unknown_suffix = substr(replace(terraform_data.unknown_value.id, "-", ""), 0, 4)
 }
 
 resource "lxd_network" "network" {

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -381,6 +381,49 @@ func TestAccNetwork_clusterConfigLifecycle(t *testing.T) {
 	})
 }
 
+// TestAccNetwork_clusterMemberOverrideUnknownConfigValue verifies that a
+// clustered network can be created with a member_overrides config value
+// that is only known after apply. Regression test for the ModifyPlan config
+// parsing failing on unknown values nested within an otherwise known
+// member_overrides map: the outer map (and each override's own config map)
+// were both known, but a value within a nested override config map was not.
+func TestAccNetwork_clusterMemberOverrideUnknownConfigValue(t *testing.T) {
+	targets := acctest.PreCheckClustering(t, 2)
+	networkName := acctest.GenerateName(2, "-")
+
+	// Use a node-specific bridge config key so the test does not depend on
+	// physical network interfaces being present on the cluster members.
+	configKey := "bridge.external_interfaces"
+	overrideTarget := targets[0]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccNetwork_clusterMemberOverrideUnknownConfigValue(networkName, overrideTarget, configKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_network.network", "name", networkName),
+					resource.TestCheckResourceAttrWith("lxd_network.network", fmt.Sprintf("member_overrides.%s.config.%s", overrideTarget, configKey), func(value string) error {
+						if !strings.HasPrefix(value, "nosuchint-") {
+							return fmt.Errorf("expected member override config value to have prefix %q, got %q", "nosuchint-", value)
+						}
+
+						return nil
+					}),
+					resource.TestCheckResourceAttrWith("lxd_network.network", fmt.Sprintf("members.%s.config.%s", overrideTarget, configKey), func(value string) error {
+						if !strings.HasPrefix(value, "nosuchint-") {
+							return fmt.Errorf("expected member config value to have prefix %q, got %q", "nosuchint-", value)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetwork_project(t *testing.T) {
 	projectName := acctest.GenerateName(2, "-")
 	networkName := acctest.GenerateName(2, "-")
@@ -672,6 +715,32 @@ resource "lxd_network" "network" {
 	b.WriteString("}\n")
 
 	return b.String()
+}
+
+func testAccNetwork_clusterMemberOverrideUnknownConfigValue(networkName string, target string, configKey string) string {
+	return fmt.Sprintf(`
+resource "terraform_data" "unknown_value" {}
+
+locals {
+  # A value only known after apply (terraform_data.id is a random UUID
+  # assigned on create), nested within member_overrides, simulating e.g. an
+  # externally allocated value resolved via a depends_on chain.
+  unknown_suffix = substr(replace(terraform_data.unknown_value.id, "-", ""), 0, 6)
+}
+
+resource "lxd_network" "network" {
+  name = %q
+  type = "bridge"
+
+  member_overrides = {
+    %q = {
+      config = {
+        %q = "nosuchint-${local.unknown_suffix}"
+      }
+    }
+  }
+}
+`, networkName, target, configKey)
 }
 
 func testAccNetwork_project(networkName string, projectName string) string {

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -151,6 +151,31 @@ func (r *StoragePoolResource) Configure(_ context.Context, req resource.Configur
 	r.provider = provider
 }
 
+// memberOverridesHaveUnknownConfig reports whether any entry of an otherwise
+// known member_overrides map contains a config value that is only known
+// after apply. The outer map can be fully known (all member keys present)
+// while a nested override's "config" attribute, or a value within it,
+// remains unknown, which ToConfigMap cannot convert.
+func memberOverridesHaveUnknownConfig(ctx context.Context, memberOverrides types.Map) bool {
+	if memberOverrides.IsNull() || memberOverrides.IsUnknown() {
+		return false
+	}
+
+	overrides := map[string]StoragePoolMemberModel{}
+	diags := memberOverrides.ElementsAs(ctx, &overrides, true)
+	if diags.HasError() {
+		return false
+	}
+
+	for _, override := range overrides {
+		if common.ConfigHasUnknownValue(override.Config) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (r *StoragePoolResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		// Nothing to do on destroy.
@@ -164,8 +189,11 @@ func (r *StoragePoolResource) ModifyPlan(ctx context.Context, req resource.Modif
 		return
 	}
 
-	// Cannot expand members if driver or member_overrides are not yet known.
-	if plan.Driver.IsUnknown() || plan.MemberOverrides.IsUnknown() {
+	// Cannot expand members if driver or member_overrides are not yet known,
+	// or if config (global or within a member override) contains a value
+	// that is only known after apply (e.g. sourced from a resource applied
+	// later in the same plan).
+	if plan.Driver.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || memberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
 		return
 	}
 

--- a/internal/storage/resource_storage_pool_test.go
+++ b/internal/storage/resource_storage_pool_test.go
@@ -304,6 +304,36 @@ func TestAccStoragePool_configSource(t *testing.T) {
 	}
 }
 
+// TestAccStoragePool_unknownConfigValue verifies that a storage pool can be
+// created with a config value that is only known after apply (e.g. sourced
+// from another resource applied in the same plan). Regression test for the
+// ModifyPlan config parsing failing on unknown values within an otherwise
+// known config map.
+func TestAccStoragePool_unknownConfigValue(t *testing.T) {
+	poolName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccStoragePool_unknownConfigValue(poolName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "driver", "zfs"),
+					resource.TestCheckResourceAttrWith("lxd_storage_pool.storage_pool1", "config.size", func(value string) error {
+						if !strings.HasSuffix(value, "MiB") {
+							return fmt.Errorf("expected config.size to have suffix %q, got %q", "MiB", value)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccStoragePool_project(t *testing.T) {
 	poolName := acctest.GenerateName(2, "-")
 	projectName := acctest.GenerateName(2, "-")
@@ -498,6 +528,42 @@ func TestAccStoragePool_clusterConfigLifecycle(t *testing.T) {
 	})
 }
 
+// TestAccStoragePool_clusterMemberOverrideUnknownConfigValue verifies that a
+// clustered storage pool can be created with a member_overrides config
+// value that is only known after apply. Regression test for the ModifyPlan
+// config parsing failing on unknown values nested within an otherwise known
+// member_overrides map: the outer map (and each override's own config map)
+// were both known, but a value within a nested override config map was not.
+func TestAccStoragePool_clusterMemberOverrideUnknownConfigValue(t *testing.T) {
+	targets := acctest.PreCheckClustering(t, 2)
+	poolName := acctest.GenerateName(2, "-")
+
+	// Use the "dir" driver with the "source.recover" key (a node-specific boolean key) so the
+	// test does not depend on loop devices or kernel storage modules, which are unavailable
+	// when LXD runs nested in a container, as is the case in the cluster test environment.
+	driverName := "dir"
+	configKey := "source.recover"
+	overrideTarget := targets[0]
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "storage_source_recover")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccStoragePool_clusterMemberOverrideUnknownConfigValue(poolName, driverName, overrideTarget, configKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool", "name", poolName),
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool", fmt.Sprintf("member_overrides.%s.config.%s", overrideTarget, configKey), "false"),
+					resource.TestCheckResourceAttr("lxd_storage_pool.pool", fmt.Sprintf("members.%s.config.%s", overrideTarget, configKey), "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccStoragePool_importBasic(t *testing.T) {
 	poolName := acctest.GenerateName(2, "-")
 	driverName := "zfs"
@@ -684,6 +750,57 @@ resource "lxd_storage_pool" "pool" {
 
 	b.WriteString("}\n")
 	return b.String()
+}
+
+func testAccStoragePool_unknownConfigValue(poolName string) string {
+	return fmt.Sprintf(`
+resource "terraform_data" "unknown_value" {}
+
+locals {
+  # A value only known after apply (terraform_data.id is a random UUID
+  # assigned on create), simulating e.g. an externally allocated size
+  # resolved via a depends_on chain.
+  unknown_octet = parseint(substr(replace(terraform_data.unknown_value.id, "-", ""), 0, 1), 16)
+}
+
+resource "lxd_storage_pool" "storage_pool1" {
+  name   = "%s"
+  driver = "zfs"
+
+  config = {
+    size = "${128 + local.unknown_octet}MiB"
+  }
+}
+`, poolName)
+}
+
+func testAccStoragePool_clusterMemberOverrideUnknownConfigValue(poolName string, driver string, target string, configKey string) string {
+	return fmt.Sprintf(`
+resource "terraform_data" "unknown_value" {}
+
+locals {
+  # A value only known after apply (terraform_data.id is a random UUID
+  # assigned on create), nested within member_overrides, simulating e.g. an
+  # externally allocated value resolved via a depends_on chain. The
+  # condition is unknown during plan, but both branches agree, so the
+  # resolved value is always "false".
+  unknown_octet = parseint(substr(replace(terraform_data.unknown_value.id, "-", ""), 0, 1), 16)
+  unknown_bool  = local.unknown_octet >= 0 ? "false" : "false"
+}
+
+resource "lxd_storage_pool" "pool" {
+  name   = %q
+  driver = %q
+
+  member_overrides = {
+    %q = {
+      config = {
+        %q = local.unknown_bool
+      }
+    }
+  }
+}
+`, poolName, driver, target, configKey)
 }
 
 // ensureSource ensures temporary storage pool source is created based on the provided


### PR DESCRIPTION
Fixes #766

ModifyPlan eagerly parsed the planned config map to expand per-member config, but only guarded against the whole map being unknown, not individual unknown values within it (e.g. a config value sourced from a resource applied later in the same plan). This caused:

  Error: Failed to parse network configuration
  Unable to convert network config to map: ...
  Received unknown value, however the target type cannot handle
  unknown values.

for any lxd_network whose config references a not-yet-applied resource/data source, a previously-working (v2.x) pattern.

Skip member expansion in ModifyPlan when config contains any unknown value, deferring to Create/Update where all values are guaranteed known.

Adds internal/common.ConfigHasUnknownValue and a regression test.