### PR TITLE
auth: DevLXD bearer tokens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      # Docker sets the iptables FORWARD policy to DROP, which blocks egress from instances on LXD bridges.
+      - name: Remove Docker
+        uses: canonical/lxd/.github/actions/disable-docker@c5184be310b13a8be5d9a5f286bfa1c0c286716e # lxd-5.21.5
+
       - name: Setup LXD from ${{ matrix.channel }} channel
         run: |
           sudo snap refresh lxd --channel=${{ matrix.channel }} --cohort=+ || sudo snap install lxd --channel=${{ matrix.channel }} --cohort=+

--- a/docs/data-sources/auth_identity.md
+++ b/docs/data-sources/auth_identity.md
@@ -15,7 +15,7 @@ data "lxd_auth_identity" "id" {
 
 * `name` - **Required** - Name of the identity.
 
-* `type` - **Required** - Identity type, can be `tls`, `bearer`, or `oidc`.
+* `type` - **Required** - Identity type, can be `tls`, `bearer`, `devlxd`, or `oidc`.
   See [Note on `auth_method`](#note-on-auth_method).
 
 * `remote` - *Optional* - The remote in which the resource will be created. If

--- a/docs/resources/auth_identity.md
+++ b/docs/resources/auth_identity.md
@@ -2,12 +2,28 @@
 
 Manages LXD identities.
 
+## Required API extensions
+
+The target LXD server must support the following API extensions:
+
+* `access_management_tls` - For identities of type `tls`.
+* `auth_bearer` - For identities of type `bearer`.
+* `auth_bearer_devlxd` - For identities of type `devlxd`.
+
 ## Example Usage
 
 ```hcl
 resource "lxd_auth_identity" "bearer-identity" {
   type   = "bearer"
   name   = "bearer-server-admin"
+  groups = ["admins"]
+}
+```
+
+```hcl
+resource "lxd_auth_identity" "devlxd-identity" {
+  type   = "devlxd"
+  name   = "devlxd-server-admin"
   groups = ["admins"]
 }
 ```
@@ -48,7 +64,7 @@ Requires the `access_management_tls` API extension.
 
 * `name` - **Required** - Name of the identity.
 
-* `type` - **Required** - Identity type, can be `tls` or `bearer`.
+* `type` - **Required** - Identity type, can be `tls`, `bearer`, or `devlxd`.
   See [Note on `auth_method`](#note-on-auth_method).
 
 * `groups` - *Optional* - List of group names to add this identity to.
@@ -79,8 +95,10 @@ This resource exports the following attributes in addition to the arguments abov
 `tls_certificate` attribute. If the certificate is omitted, the identity is created in a
 pending state and a trust token is issued instead.
 
-`bearer` identities authenticate using a token, which is issued with the
-[`lxd_auth_identity_token`](auth_identity_token.md) resource and is accepted by the LXD API.
+`bearer` and `devlxd` identities authenticate using a token, which is issued with the
+[`lxd_auth_identity_token`](auth_identity_token.md) resource. Both use the LXD `bearer`
+authentication method and differ only in where their tokens are accepted. A `bearer` token is
+accepted by the LXD API, and a `devlxd` token is accepted by the DevLXD API within an instance.
 
 ## Pending TLS trust token lifecycle
 

--- a/docs/resources/auth_identity_token.md
+++ b/docs/resources/auth_identity_token.md
@@ -1,14 +1,15 @@
 # lxd_auth_identity_token
 
 The `lxd_auth_identity_token` resource allows you to issue a token for an LXD
-identity of type `bearer`.
+identity of type `bearer` or `devlxd`.
 
 ## Required API extensions
 
 The target LXD server must support the following API extensions:
 
 * `access_management_expiry`
-* `auth_bearer`
+* `auth_bearer` - For identities of type `bearer`.
+* `auth_bearer_devlxd` - For identities of type `devlxd`.
 
 ~> **Warning:** The issued token is stored in the Terraform state in plain text.
   Anyone who can read the state can authenticate against the LXD server as the
@@ -36,6 +37,30 @@ resource "lxd_auth_identity_token" "token" {
 output "token" {
   value     = lxd_auth_identity_token.token.token
   sensitive = true
+}
+```
+
+### Identity type change
+
+Changing identity type replaces the identity and revokes its token.
+The token resource references the identity by name, which does not change, so Terraform notices the
+revoked token only on the next plan.
+To issue a new token in the same apply, replace the token whenever the identity type changes:
+
+```hcl
+resource "lxd_auth_identity" "identity" {
+  type   = "bearer"
+  name   = "server-admin"
+  groups = ["admins"]
+}
+
+resource "lxd_auth_identity_token" "token" {
+  identity = lxd_auth_identity.identity.name
+  expiry   = "30d"
+
+  lifecycle {
+    replace_triggered_by = [lxd_auth_identity.identity.type]
+  }
 }
 ```
 

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -453,3 +453,7 @@ import {
 * Terraform LXD provider sets `user.managed-by` key to all managed instance devices.
   Removing that key from a device manually, would result in Terraform removing it on next apply.
 
+* Devices attached to the instance over the DevLXD API are owned by a DevLXD identity, which LXD
+  records in the instance configuration. Such devices are left out of the Terraform state and are
+  not removed on apply.
+

--- a/internal/auth/datasource_identity.go
+++ b/internal/auth/datasource_identity.go
@@ -53,7 +53,7 @@ func (r AuthIdentityDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 				Optional: true,
 				Computed: true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("tls", "bearer", "oidc"),
+					stringvalidator.OneOf("tls", "bearer", "devlxd", "oidc"),
 				},
 			},
 
@@ -135,7 +135,7 @@ func (r *AuthIdentityDataSource) Read(ctx context.Context, req datasource.ReadRe
 	// Exactly one of the two is configured, and each derives the other. Every
 	// authentication method is also an identity type.
 	if identityAuthMethod == "" {
-		identityAuthMethod = identityType
+		identityAuthMethod = toAuthMethod(identityType)
 	} else {
 		identityType = identityAuthMethod
 	}
@@ -146,10 +146,20 @@ func (r *AuthIdentityDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	// The identity type is taken from the server. LXD identity types that the
-	// provider cannot name keep the identity type that was asked for.
+	// The bearer authentication method returns client and devlxd identities
+	// alike, so a lookup by identity type must reject an identity of another
+	// type. LXD identity types that the provider cannot name keep the identity
+	// type that was asked for.
 	serverType := toType(identity.Type)
 	if serverType != "" {
+		if !config.Type.IsNull() && serverType != identityType {
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Identity %q is not of type %q", identityName, identityType),
+				fmt.Sprintf("LXD identity type %q corresponds to type %q", identity.Type, serverType),
+			)
+			return
+		}
+
 		identityType = serverType
 	}
 

--- a/internal/auth/datasource_identity_test.go
+++ b/internal/auth/datasource_identity_test.go
@@ -39,6 +39,11 @@ func TestAccIdentity_DS_bearer(t *testing.T) {
 					resource.TestCheckResourceAttr("data.lxd_auth_identity.identity", "groups.0", "admins"),
 				),
 			},
+			{
+				// Look up a client bearer identity as a devlxd identity.
+				Config:      acctest.Provider() + testAccIdentity_DS_bearerAsDevlxd(identity, []string{"admins"}),
+				ExpectError: regexp.MustCompile(`LXD identity type "Client token bearer"`),
+			},
 		},
 	})
 }
@@ -111,6 +116,45 @@ func TestAccIdentity_DS_tlsPending(t *testing.T) {
 	})
 }
 
+func TestAccIdentity_DS_devlxd(t *testing.T) {
+	identity := acctest.GenerateName(2, "-")
+	dataSourceName := "data.lxd_auth_identity.identity"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "access_management", "auth_bearer_devlxd")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Look up by identity type.
+				Config: acctest.Provider() + testAccIdentity_DS_devlxdByType(identity),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", identity),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "devlxd"),
+					resource.TestCheckResourceAttr(dataSourceName, "auth_method", "bearer"),
+				),
+			},
+			{
+				// Look up by authentication method, which does not distinguish
+				// client bearer identities from devlxd ones.
+				Config: acctest.Provider() + testAccIdentity_DS_devlxdByAuthMethod(identity),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name", identity),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "devlxd"),
+					resource.TestCheckResourceAttr(dataSourceName, "auth_method", "bearer"),
+				),
+			},
+			{
+				// Look up a devlxd identity as a client bearer identity.
+				Config:      acctest.Provider() + testAccIdentity_DS_devlxdAsBearer(identity),
+				ExpectError: regexp.MustCompile(`LXD identity type "DevLXD token bearer"`),
+			},
+		},
+	})
+}
+
 func TestAccIdentity_DS_typeValidation(t *testing.T) {
 	identity := acctest.GenerateName(2, "-")
 
@@ -158,6 +202,42 @@ func testAccIdentity_DS_tlsPending(name string) string {
 		  name        = lxd_auth_identity.identity.name
 		}
 	`
+}
+
+func testAccIdentity_DS_devlxdByType(name string) string {
+	return testAccIdentity_type(name, "devlxd", []string{}) + `
+                data "lxd_auth_identity" "identity" {
+                  type = "devlxd"
+                  name = lxd_auth_identity.identity.name
+                }
+        `
+}
+
+func testAccIdentity_DS_devlxdByAuthMethod(name string) string {
+	return testAccIdentity_type(name, "devlxd", []string{}) + `
+                data "lxd_auth_identity" "identity" {
+                  auth_method = "bearer"
+                  name        = lxd_auth_identity.identity.name
+                }
+        `
+}
+
+func testAccIdentity_DS_devlxdAsBearer(name string) string {
+	return testAccIdentity_type(name, "devlxd", []string{}) + `
+                data "lxd_auth_identity" "identity" {
+                  type = "bearer"
+                  name = lxd_auth_identity.identity.name
+                }
+        `
+}
+
+func testAccIdentity_DS_bearerAsDevlxd(name string, groups []string) string {
+	return testAccIdentity_type(name, "bearer", groups) + `
+                data "lxd_auth_identity" "identity" {
+                  type = "devlxd"
+                  name = lxd_auth_identity.identity.name
+                }
+        `
 }
 
 func testAccIdentity_DS_noAttributes(name string) string {

--- a/internal/auth/identity_type.go
+++ b/internal/auth/identity_type.go
@@ -4,6 +4,18 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
+// toAuthMethod returns the authentication method for the given identity type.
+// The authentication method is the path segment of every identity endpoint,
+// and a devlxd identity is reached through the bearer method. Every other
+// identity type the provider accepts is also an authentication method.
+func toAuthMethod(identityType string) string {
+	if identityType == "devlxd" {
+		return api.AuthenticationMethodBearer
+	}
+
+	return identityType
+}
+
 // toType returns the identity type for the given LXD identity type. LXD
 // identity types that the provider cannot name return an empty string.
 func toType(lxdIdentityType string) string {
@@ -15,6 +27,8 @@ func toType(lxdIdentityType string) string {
 		return "tls"
 	case api.IdentityTypeBearerTokenClient:
 		return "bearer"
+	case api.IdentityTypeBearerTokenDevLXD:
+		return "devlxd"
 	case api.IdentityTypeOIDCClient:
 		// Only the data source accepts oidc.
 		return "oidc"

--- a/internal/auth/identity_type_test.go
+++ b/internal/auth/identity_type_test.go
@@ -7,6 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestToAuthMethod(t *testing.T) {
+	var tests = []struct {
+		IdentityType string
+		Expect       string
+	}{
+		{IdentityType: "tls", Expect: "tls"},
+		{IdentityType: "bearer", Expect: "bearer"},
+		{IdentityType: "devlxd", Expect: "bearer"},
+		{IdentityType: "oidc", Expect: "oidc"},
+		{IdentityType: "", Expect: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.IdentityType, func(t *testing.T) {
+			assert.Equal(t, test.Expect, toAuthMethod(test.IdentityType))
+		})
+	}
+}
+
 func TestToType(t *testing.T) {
 	var tests = []struct {
 		LXDIdentityType string
@@ -17,7 +36,7 @@ func TestToType(t *testing.T) {
 		{LXDIdentityType: api.IdentityTypeCertificateClientUnrestricted, Expect: "tls"},
 		{LXDIdentityType: api.IdentityTypeCertificateClientPending, Expect: "tls"},
 		{LXDIdentityType: api.IdentityTypeBearerTokenClient, Expect: "bearer"},
-		{LXDIdentityType: api.IdentityTypeBearerTokenDevLXD, Expect: ""},
+		{LXDIdentityType: api.IdentityTypeBearerTokenDevLXD, Expect: "devlxd"},
 		{LXDIdentityType: api.IdentityTypeOIDCClient, Expect: "oidc"},
 		{LXDIdentityType: api.IdentityTypeCertificateServer, Expect: ""},
 		{LXDIdentityType: api.IdentityTypeCertificateMetricsRestricted, Expect: ""},

--- a/internal/auth/resource_identity.go
+++ b/internal/auth/resource_identity.go
@@ -72,7 +72,7 @@ func (r AuthIdentityResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional: true,
 				Computed: true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("tls", "bearer"),
+					stringvalidator.OneOf("tls", "bearer", "devlxd"),
 				},
 				PlanModifiers: []planmodifier.String{
 					// Derivation must run before the replacement condition.
@@ -216,7 +216,7 @@ func (r AuthIdentityResource) Create(ctx context.Context, req resource.CreateReq
 				plan.ExpiresAt = tokenExpiry(token.ExpiresAt)
 			}
 		}
-	case "bearer":
+	case "bearer", "devlxd":
 		if hasTLSCertificate {
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Invalid %q identity %q", identityType, identityName),
@@ -225,10 +225,15 @@ func (r AuthIdentityResource) Create(ctx context.Context, req resource.CreateReq
 			return
 		}
 
+		bearerType := api.IdentityTypeBearerTokenClient
+		if identityType == "devlxd" {
+			bearerType = api.IdentityTypeBearerTokenDevLXD
+		}
+
 		req := api.IdentitiesBearerPost{
 			Name:   identityName,
 			Groups: identityGroupNames,
-			Type:   api.IdentityTypeBearerTokenClient,
+			Type:   bearerType,
 		}
 
 		err = server.CreateIdentityBearer(req)
@@ -361,8 +366,9 @@ func (r AuthIdentityResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	identityName := state.Name.ValueString()
 	identityType := state.identityType()
+	identityAuthMethod := toAuthMethod(identityType)
 
-	err = server.DeleteIdentity(identityType, identityName)
+	err = server.DeleteIdentity(identityAuthMethod, identityName)
 	if err != nil && !errors.IsNotFoundError(err) {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to delete %q identity %q", identityType, identityName), err.Error())
 		return
@@ -451,8 +457,9 @@ func (r AuthIdentityResource) SyncState(ctx context.Context, tfState *tfsdk.Stat
 
 	identityName := m.Name.ValueString()
 	identityType := m.identityType()
+	identityAuthMethod := toAuthMethod(identityType)
 
-	identity, _, err := server.GetIdentity(identityType, identityName)
+	identity, _, err := server.GetIdentity(identityAuthMethod, identityName)
 	if err != nil {
 		if forgetOnNotFound && errors.IsNotFoundError(err) {
 			tfState.RemoveResource(ctx)
@@ -463,8 +470,9 @@ func (r AuthIdentityResource) SyncState(ctx context.Context, tfState *tfsdk.Stat
 		return respDiags
 	}
 
-	// The identity type is taken from the server. LXD identity types that the
-	// provider cannot name keep the identity type already in state.
+	// The bearer authentication method returns client and devlxd identities
+	// alike, so the identity type is taken from the server. LXD identity types
+	// that the provider cannot name keep the identity type already in state.
 	serverType := toType(identity.Type)
 	if serverType != "" {
 		identityType = serverType

--- a/internal/auth/resource_identity.go
+++ b/internal/auth/resource_identity.go
@@ -145,6 +145,7 @@ func (r *AuthIdentityResource) Configure(_ context.Context, req resource.Configu
 func (r AuthIdentityResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		identityTypeValidator{},
+		identityCertificateValidator{},
 	}
 }
 
@@ -312,6 +313,16 @@ func (r AuthIdentityResource) Update(ctx context.Context, req resource.UpdateReq
 
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("tls_certificate"), &configTLSCertificate)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Checked again here, because the configuration validator skips an identity type that is
+	// unknown until apply.
+	if !configTLSCertificate.IsNull() && identityType != "tls" {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Invalid %q identity %q", identityType, identityName),
+			fmt.Sprintf("Certificate must not be set for identities of type %q", identityType),
+		)
 		return
 	}
 

--- a/internal/auth/resource_identity_test.go
+++ b/internal/auth/resource_identity_test.go
@@ -85,6 +85,65 @@ func TestAccIdentity_tls(t *testing.T) {
 	})
 }
 
+func TestAccIdentity_devlxd(t *testing.T) {
+	identity := acctest.GenerateName(2, "-")
+	resourceName := "lxd_auth_identity.identity"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "access_management", "auth_bearer_devlxd")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Create identity.
+				Config: acctest.Provider() + testAccIdentity_type(identity, "devlxd", []string{}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", identity),
+					resource.TestCheckResourceAttr(resourceName, "type", "devlxd"),
+					resource.TestCheckResourceAttr(resourceName, "auth_method", "bearer"),
+					resource.TestCheckResourceAttr(resourceName, "groups.#", "0"),
+				),
+			},
+			{
+				// Update groups.
+				Config: acctest.Provider() + testAccIdentity_type(identity, "devlxd", []string{"admins"}),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", identity),
+					resource.TestCheckResourceAttr(resourceName, "type", "devlxd"),
+					resource.TestCheckResourceAttr(resourceName, "auth_method", "bearer"),
+					resource.TestCheckResourceAttr(resourceName, "groups.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "groups.0", "admins"),
+				),
+			},
+			{
+				// Import by identity type.
+				ResourceName:                         resourceName,
+				ImportStateId:                        fmt.Sprintf("/devlxd/%s", identity),
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+			{
+				// Import by authentication method. The read that follows the import
+				// records the identity type the server reports, which the verification
+				// against the prior state asserts is devlxd.
+				ResourceName:                         resourceName,
+				ImportStateId:                        fmt.Sprintf("/bearer/%s", identity),
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
 func TestAccIdentity_tlsPending(t *testing.T) {
 	identity := acctest.GenerateName(2, "-")
 	resourceName := "lxd_auth_identity.identity"
@@ -208,10 +267,16 @@ func TestAccIdentity_typeTransitions(t *testing.T) {
 		},
 	}
 
+	expectReplace := resource.ConfigPlanChecks{
+		PreApply: []plancheck.PlanCheck{
+			plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionReplace),
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
-			acctest.PreCheckAPIExtensions(t, "access_management", "auth_bearer")
+			acctest.PreCheckAPIExtensions(t, "access_management", "auth_bearer_devlxd")
 		},
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -232,6 +297,29 @@ func TestAccIdentity_typeTransitions(t *testing.T) {
 				// State bearer/bearer, configured type bearer.
 				Config:           acctest.Provider() + testAccIdentity_type(identity, "bearer", []string{}),
 				ConfigPlanChecks: expectEmptyPlan,
+			},
+			{
+				// State bearer/bearer, configured type devlxd.
+				Config:           acctest.Provider() + testAccIdentity_type(identity, "devlxd", []string{}),
+				ConfigPlanChecks: expectReplace,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "devlxd"),
+					resource.TestCheckResourceAttr(resourceName, "auth_method", "bearer"),
+				),
+			},
+			{
+				// State bearer/devlxd, configured type devlxd.
+				Config:           acctest.Provider() + testAccIdentity_type(identity, "devlxd", []string{}),
+				ConfigPlanChecks: expectEmptyPlan,
+			},
+			{
+				// State bearer/devlxd, configured auth_method bearer.
+				Config:           acctest.Provider() + testAccIdentity_bearer(identity, []string{}),
+				ConfigPlanChecks: expectReplace,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "bearer"),
+					resource.TestCheckResourceAttr(resourceName, "auth_method", "bearer"),
+				),
 			},
 		},
 	})

--- a/internal/auth/resource_identity_test.go
+++ b/internal/auth/resource_identity_test.go
@@ -107,6 +107,11 @@ func TestAccIdentity_devlxd(t *testing.T) {
 				),
 			},
 			{
+				// Setting a certificate on an existing identity is rejected before the update.
+				Config:      acctest.Provider() + testAccIdentity_typeWithCertificate(identity, "devlxd"),
+				ExpectError: regexp.MustCompile(`Certificate must not be set for identities of type "devlxd"`),
+			},
+			{
 				// Update groups.
 				Config: acctest.Provider() + testAccIdentity_type(identity, "devlxd", []string{"admins"}),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -399,7 +404,7 @@ func TestAccIdentity_typeValidation(t *testing.T) {
 				ExpectError: regexp.MustCompile(`value must be one of`),
 			},
 			{
-				Config:      acctest.Provider() + testAccIdentity_bearerWithCertificate(identity),
+				Config:      acctest.Provider() + testAccIdentity_typeWithCertificate(identity, "bearer"),
 				ExpectError: regexp.MustCompile(`Certificate must not be set for identities of type "bearer"`),
 			},
 		},
@@ -608,16 +613,16 @@ func testAccIdentity_noAttributes(name string) string {
 	)
 }
 
-// testAccIdentity_bearerWithCertificate is rejected before the identity is
-// created, so the certificate does not have to be a valid one.
-func testAccIdentity_bearerWithCertificate(name string) string {
+// testAccIdentity_typeWithCertificate is rejected before the certificate
+// reaches the server, so it does not have to be a valid one.
+func testAccIdentity_typeWithCertificate(name string, identityType string) string {
 	return fmt.Sprintf(`
                 resource "lxd_auth_identity" "identity" {
-		  type            = "bearer"
+                  type            = %q
                   name            = %q
                   tls_certificate = "not-a-certificate"
                 }
         `,
-		name,
+		identityType, name,
 	)
 }

--- a/internal/auth/resource_identity_token_test.go
+++ b/internal/auth/resource_identity_token_test.go
@@ -2,11 +2,13 @@ package auth_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 )
 
@@ -37,6 +39,139 @@ func TestAccIdentityToken_bearer(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_auth_identity_token.token", "expiry", "2H"),
 					resource.TestCheckResourceAttrSet("lxd_auth_identity_token.token", "token"),
 					resource.TestCheckResourceAttrWith("lxd_auth_identity_token.token", "expires_at", checkExpiresInFuture),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentityToken_devlxd(t *testing.T) {
+	identity := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "auth_bearer_devlxd", "access_management_expiry")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Issue token.
+				Config: acctest.Provider() + testAccIdentityToken(identity, "devlxd", "30d"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_auth_identity_token.token", "identity", identity),
+					resource.TestCheckResourceAttr("lxd_auth_identity_token.token", "expiry", "30d"),
+					resource.TestCheckResourceAttrSet("lxd_auth_identity_token.token", "token"),
+					resource.TestCheckResourceAttrWith("lxd_auth_identity_token.token", "expires_at", checkExpiresInFuture),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentityToken_devlxdSocket(t *testing.T) {
+	identity := acctest.GenerateName(2, "-")
+	group := acctest.GenerateName(2, "-")
+	instance := acctest.GenerateName(2, "-")
+	pool := acctest.GenerateName(2, "-")
+	network := acctest.GenerateName(2, "-")
+	volume := acctest.GenerateName(2, "-")
+	subnet := acctest.GenerateSubnet()
+
+	instanceName := "lxd_instance.instance"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "auth_bearer_devlxd", "access_management_expiry", "devlxd_volume_management")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// The token of a devlxd identity must be accepted by the DevLXD
+				// API, which is verified by listing the volumes of an empty
+				// storage pool, creating one from within the instance, and
+				// attaching it to that same instance. Both the volume and the
+				// device are owned by the identity that created them.
+				Config: acctest.Provider() + testAccIdentityToken_devlxdSocket(identity, group, instance, pool, network, subnet, volume, "", false, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("lxd_auth_identity_token.token", "token"),
+					resource.TestCheckResourceAttr(instanceName, "status", "Running"),
+					resource.TestCheckResourceAttr(instanceName, "execs.01-install-curl.exit_code", "0"),
+					resource.TestCheckResourceAttr(instanceName, "execs.02-list-volumes.exit_code", "0"),
+					resource.TestCheckResourceAttr(instanceName, "execs.02-list-volumes.stdout", "200 []"),
+					resource.TestCheckResourceAttr(instanceName, "execs.03-create-volume.exit_code", "0"),
+					resource.TestMatchResourceAttr(instanceName, "execs.03-create-volume.stdout", regexp.MustCompile(`"name":"`+volume+`"`)),
+					resource.TestMatchResourceAttr(instanceName, "execs.03-create-volume.stdout", regexp.MustCompile(`"volatile\.devlxd\.owner":`)),
+					resource.TestCheckResourceAttr(instanceName, "execs.04-attach-volume.exit_code", "0"),
+					resource.TestMatchResourceAttr(instanceName, "execs.04-attach-volume.stdout", regexp.MustCompile(`"source":"`+volume+`"`)),
+
+					// The attached device is owned by the devlxd identity, so it
+					// is not recorded in the instance state.
+					resource.TestCheckResourceAttr(instanceName, "device.#", "1"),
+					resource.TestCheckResourceAttr(instanceName, "device.0.name", "eth0"),
+				),
+			},
+			{
+				// Neither the volume nor the device that attaches it to the
+				// instance is managed by Terraform, therefore they produce no
+				// drift.
+				Config: acctest.Provider() + testAccIdentityToken_devlxdSocket(identity, group, instance, pool, network, subnet, volume, "", false, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				// An update of the instance must keep the device that the
+				// devlxd identity attached, even though the device is absent
+				// from the plan.
+				Config: acctest.Provider() + testAccIdentityToken_devlxdSocket(identity, group, instance, pool, network, subnet, volume, "updated", false, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(instanceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(instanceName, "config.user.dummy", "updated"),
+					resource.TestCheckResourceAttr(instanceName, "device.#", "1"),
+					resource.TestCheckResourceAttr(instanceName, "device.0.name", "eth0"),
+					func(_ *terraform.State) error {
+						server := acctest.InstanceServer(t)
+
+						inst, _, err := server.GetInstance(instance)
+						if err != nil {
+							return fmt.Errorf("Failed to retrieve instance %q: %w", instance, err)
+						}
+
+						device, ok := inst.Devices[volume]
+						if !ok {
+							return fmt.Errorf("Device %q attached over the DevLXD socket was removed from instance %q", volume, instance)
+						}
+
+						if device["source"] != volume {
+							return fmt.Errorf("Device %q on instance %q has source %q, expected %q", volume, instance, device["source"], volume)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				// The update must be rejected when a device block has the name
+				// of the device owned by the devlxd identity.
+				Config:      acctest.Provider() + testAccIdentityToken_devlxdSocket(identity, group, instance, pool, network, subnet, volume, "updated", true, false),
+				ExpectError: regexp.MustCompile("Cannot modify an owned device"),
+			},
+			{
+				// Terraform cannot remove a volume it does not manage, and the
+				// storage pool cannot be destroyed while the volume exists, so
+				// the volume is detached and removed over the DevLXD socket.
+				Config: acctest.Provider() + testAccIdentityToken_devlxdSocket(identity, group, instance, pool, network, subnet, volume, "updated", false, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(instanceName, "execs.05-detach-volume.exit_code", "0"),
+					resource.TestCheckResourceAttr(instanceName, "execs.06-delete-volume.exit_code", "0"),
 				),
 			},
 		},
@@ -230,6 +365,333 @@ func checkExpiresInFuture(value string) error {
 	}
 
 	return nil
+}
+
+// devlxdListVolumes queries the volumes of the given storage pool over the
+// DevLXD socket using the token from the TOKEN environment variable. It prints
+// the response status with the response body, and fails if the status is not
+// 200. An authorization failure is therefore reported as a failed exec.
+//
+// The curl write-out format is escaped as "%%{" because HCL would otherwise
+// interpret "%{" as a template directive.
+const devlxdListVolumes = `
+status=$(curl \
+  -s \
+  -o /tmp/volumes \
+  -w '%%{http_code}' \
+  --unix-socket /dev/lxd/sock \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost/1.0/storage-pools/$POOL/volumes?recursion=1")
+
+printf '%s %s' "$status" "$(cat /tmp/volumes)"
+test "$status" = "200"
+`
+
+// devlxdCreateVolume creates a custom storage volume over the DevLXD socket and
+// prints the volumes that the identity owns in the pool. Volume creation is
+// asynchronous, therefore the volumes are polled for until the new one appears.
+const devlxdCreateVolume = `
+curl \
+  -s \
+  -f \
+  -o /dev/null \
+  --unix-socket /dev/lxd/sock \
+  -H "Authorization: Bearer $TOKEN" \
+  -X POST \
+  --data "{\"name\": \"$VOLUME\", \"type\": \"custom\", \"content_type\": \"filesystem\"}" \
+  "http://localhost/1.0/storage-pools/$POOL/volumes"
+
+for _ in $(seq 10); do
+  volumes=$(curl -s --unix-socket /dev/lxd/sock -H "Authorization: Bearer $TOKEN" \
+    "http://localhost/1.0/storage-pools/$POOL/volumes?recursion=1")
+
+  echo "$volumes" | grep -q "\"name\":\"$VOLUME\"" && break
+  sleep 1
+done
+
+printf '%s' "$volumes"
+echo "$volumes" | grep -q "\"name\":\"$VOLUME\""
+`
+
+// devlxdAttachVolume attaches the storage volume to the instance it was created
+// from over the DevLXD socket, and prints the instance devices that the identity
+// owns. Device attachment is asynchronous, therefore the devices are polled for
+// until the new one appears.
+const devlxdAttachVolume = `
+curl \
+  -s \
+  -f \
+  -o /dev/null \
+  --unix-socket /dev/lxd/sock \
+  -H "Authorization: Bearer $TOKEN" \
+  -X PATCH \
+  --data "{\"devices\": {\"$VOLUME\": {\"type\": \"disk\", \"pool\": \"$POOL\", \"source\": \"$VOLUME\", \"path\": \"/mnt/$VOLUME\"}}}" \
+  "http://localhost/1.0/instances/$INSTANCE"
+
+for _ in $(seq 10); do
+  instance=$(curl -s --unix-socket /dev/lxd/sock -H "Authorization: Bearer $TOKEN" \
+    "http://localhost/1.0/instances/$INSTANCE")
+
+  echo "$instance" | grep -q "\"source\":\"$VOLUME\"" && break
+  sleep 1
+done
+
+printf '%s' "$instance"
+echo "$instance" | grep -q "\"source\":\"$VOLUME\""
+`
+
+// devlxdDetachVolume detaches the storage volume from the instance over the
+// DevLXD socket. Device detachment is asynchronous, therefore the devices are
+// polled for until the removed one is gone.
+const devlxdDetachVolume = `
+curl \
+  -s \
+  -f \
+  -o /dev/null \
+  --unix-socket /dev/lxd/sock \
+  -H "Authorization: Bearer $TOKEN" \
+  -X PATCH \
+  --data "{\"devices\": {\"$VOLUME\": null}}" \
+  "http://localhost/1.0/instances/$INSTANCE"
+
+for _ in $(seq 10); do
+  instance=$(curl -s -f --unix-socket /dev/lxd/sock -H "Authorization: Bearer $TOKEN" \
+    "http://localhost/1.0/instances/$INSTANCE") || exit 1
+
+  echo "$instance" | grep -q "\"source\":\"$VOLUME\"" || exit 0
+  sleep 1
+done
+
+exit 1
+`
+
+// devlxdDeleteVolume removes the storage volume over the DevLXD socket. Volume
+// deletion is asynchronous, therefore the volumes are polled for until the
+// removed one is gone.
+const devlxdDeleteVolume = `
+curl \
+  -s \
+  -f \
+  -o /dev/null \
+  --unix-socket /dev/lxd/sock \
+  -H "Authorization: Bearer $TOKEN" \
+  -X DELETE \
+  "http://localhost/1.0/storage-pools/$POOL/volumes/custom/$VOLUME"
+
+for _ in $(seq 10); do
+  volumes=$(curl -s -f --unix-socket /dev/lxd/sock -H "Authorization: Bearer $TOKEN" \
+    "http://localhost/1.0/storage-pools/$POOL/volumes?recursion=1") || exit 1
+
+  echo "$volumes" | grep -q "\"name\":\"$VOLUME\"" || exit 0
+  sleep 1
+done
+
+exit 1
+`
+
+func testAccIdentityToken_devlxdSocket(name string, group string, instance string, pool string, network string, subnet acctest.Subnet, volume string, userConfig string, claimDevice bool, removeVolume bool) string {
+	userConfigLine := ""
+	if userConfig != "" {
+		userConfigLine = fmt.Sprintf(`"user.dummy" = %q`, userConfig)
+	}
+
+	claimDeviceBlock := ""
+	if claimDevice {
+		claimDeviceBlock = fmt.Sprintf(`
+		  device {
+		    name = %q
+		    type = "disk"
+		    properties = {
+		      pool   = lxd_storage_pool.pool.name
+		      source = %q
+		      path   = "/mnt/claimed"
+		    }
+		  }
+		`, volume, volume)
+	}
+
+	removeExecs := ""
+	if removeVolume {
+		removeExecs = fmt.Sprintf(`
+		    "05-detach-volume" = {
+		      command       = ["sh", "-c", %q]
+		      trigger       = "once"
+		      fail_on_error = true
+		      record_output = true
+
+		      environment = {
+		        TOKEN    = lxd_auth_identity_token.token.token
+		        INSTANCE = %q
+		        VOLUME   = %q
+		      }
+		    }
+
+		    "06-delete-volume" = {
+		      command       = ["sh", "-c", %q]
+		      trigger       = "once"
+		      fail_on_error = true
+		      record_output = true
+
+		      environment = {
+		        TOKEN  = lxd_auth_identity_token.token.token
+		        POOL   = lxd_storage_pool.pool.name
+		        VOLUME = %q
+		      }
+		    }
+		`, devlxdDetachVolume, instance, volume, devlxdDeleteVolume, volume)
+	}
+
+	return fmt.Sprintf(`
+		resource "lxd_storage_pool" "pool" {
+		  name   = %q
+		  driver = "dir"
+		}
+
+		# The instance needs egress to install a client that can talk to the
+		# DevLXD socket, therefore a NAT network is created for it.
+		resource "lxd_network" "network" {
+		  name = %q
+
+		  config = {
+		    "ipv4.address" = %q
+		    "ipv4.nat"     = "true"
+		    "ipv6.address" = "none"
+		  }
+		}
+
+		resource "lxd_auth_group" "group" {
+		  name = %q
+
+		  # Volume management and instance editing are granted at the project
+		  # level, because the storage pool entity type provides no volume
+		  # related entitlements, and the instance does not exist yet when the
+		  # group is created.
+		  permissions = [
+		    {
+		      entitlement = "can_view"
+		      entity_type = "project"
+		      entity_args = {
+		        name = "default"
+		      }
+		    },
+		    {
+		      entitlement = "storage_volume_manager"
+		      entity_type = "project"
+		      entity_args = {
+		        name = "default"
+		      }
+		    },
+		    {
+		      entitlement = "can_edit_instances"
+		      entity_type = "project"
+		      entity_args = {
+		        name = "default"
+		      }
+		    },
+		  ]
+		}
+
+		resource "lxd_auth_identity" "identity" {
+		  type   = "devlxd"
+		  name   = %q
+		  groups = [lxd_auth_group.group.name]
+		}
+
+		resource "lxd_auth_identity_token" "token" {
+		  identity = lxd_auth_identity.identity.name
+		  expiry   = "1H"
+		}
+
+		resource "lxd_instance" "instance" {
+		  name  = %q
+		  image = %q
+
+		  config = {
+		    "security.devlxd.management.volumes" = "true"
+		    %s
+		  }
+
+		  device {
+		    name = "eth0"
+		    type = "nic"
+		    properties = {
+		      nictype = "bridged"
+		      parent  = lxd_network.network.name
+		    }
+		  }
+		  %s
+
+		  # Execs must not run before the instance can reach the network.
+		  wait_for {
+		    type = "ipv4"
+		  }
+
+		  execs = {
+		    "01-install-curl" = {
+		      command       = ["apk", "add", "--no-cache", "curl"]
+		      trigger       = "once"
+		      fail_on_error = true
+		    }
+
+		    "02-list-volumes" = {
+		      command       = ["sh", "-c", %q]
+		      trigger       = "once"
+		      fail_on_error = true
+		      record_output = true
+
+		      environment = {
+		        TOKEN = lxd_auth_identity_token.token.token
+		        POOL  = lxd_storage_pool.pool.name
+		      }
+		    }
+
+		    "03-create-volume" = {
+		      command       = ["sh", "-c", %q]
+		      trigger       = "once"
+		      fail_on_error = true
+		      record_output = true
+
+		      environment = {
+		        TOKEN  = lxd_auth_identity_token.token.token
+		        POOL   = lxd_storage_pool.pool.name
+		        VOLUME = %q
+		      }
+		    }
+
+		    "04-attach-volume" = {
+		      command       = ["sh", "-c", %q]
+		      trigger       = "once"
+		      fail_on_error = true
+		      record_output = true
+
+		      environment = {
+		        TOKEN    = lxd_auth_identity_token.token.token
+		        INSTANCE = %q
+		        POOL     = lxd_storage_pool.pool.name
+		        VOLUME   = %q
+		      }
+		    }
+		    %s
+		  }
+		}
+	`,
+		pool,
+		network,
+		subnet.GatewayCIDRv4(),
+		group,
+		name,
+		instance,
+		acctest.TestImage,
+		userConfigLine,
+		claimDeviceBlock,
+		devlxdListVolumes,
+		devlxdCreateVolume,
+		volume,
+		devlxdAttachVolume,
+		instance,
+		volume,
+		removeExecs,
+	)
 }
 
 func testAccIdentityToken_identityDataSource(name string, withToken bool) string {

--- a/internal/auth/schema_modifiers.go
+++ b/internal/auth/schema_modifiers.go
@@ -39,10 +39,13 @@ func (m authMethodModifier) PlanModifyString(ctx context.Context, req planmodifi
 		return
 	}
 
-	// Every identity type is also an authentication method, so the value is
-	// taken as it is. An unknown identity type makes the authentication method
-	// unknown.
-	resp.PlanValue = identityType
+	// An unknown identity type makes the authentication method unknown.
+	if identityType.IsUnknown() {
+		resp.PlanValue = types.StringUnknown()
+		return
+	}
+
+	resp.PlanValue = types.StringValue(toAuthMethod(identityType.ValueString()))
 }
 
 // identityTypeModifier derives the planned type from the configured auth_method.
@@ -73,9 +76,9 @@ func (m identityTypeModifier) PlanModifyString(ctx context.Context, req planmodi
 		return
 	}
 
-	// Every authentication method is also an identity type, so the value is
-	// taken as it is. An unknown authentication method makes the identity type
-	// unknown.
+	// Attribute auth_method cannot hold devlxd, and every authentication method
+	// it can hold is also an identity type, so the value is taken as it is. An
+	// unknown authentication method makes the identity type unknown.
 	resp.PlanValue = authMethod
 }
 

--- a/internal/auth/schema_modifiers_test.go
+++ b/internal/auth/schema_modifiers_test.go
@@ -85,6 +85,13 @@ func TestAuthMethodModifier(t *testing.T) {
 			Expect:         types.StringValue("bearer"),
 		},
 		{
+			Name:           "Derived from the configured devlxd identity type",
+			ConfigType:     "devlxd",
+			PlanAuthMethod: tftypes.UnknownValue,
+			PlanType:       "devlxd",
+			Expect:         types.StringValue("bearer"),
+		},
+		{
 			Name:           "Unknown identity type",
 			ConfigType:     tftypes.UnknownValue,
 			PlanAuthMethod: tftypes.UnknownValue,
@@ -148,6 +155,15 @@ func TestIdentityTypeModifier(t *testing.T) {
 			ConfigAuthMethod: "bearer",
 			PlanAuthMethod:   "bearer",
 			PlanType:         "tls",
+			Expect:           types.StringValue("bearer"),
+		},
+		{
+			// A prior state holding devlxd carries that value into the plan,
+			// which is the drift the derivation exists to report.
+			Name:             "Derived from the authentication method of a devlxd identity",
+			ConfigAuthMethod: "bearer",
+			PlanAuthMethod:   "bearer",
+			PlanType:         "devlxd",
 			Expect:           types.StringValue("bearer"),
 		},
 		{
@@ -217,6 +233,13 @@ func TestRequiresReplaceIdentityType(t *testing.T) {
 			StateAuthMethod: "tls",
 			PlanType:        "tls",
 			Expect:          false,
+		},
+		{
+			Name:            "Identity type changed to devlxd",
+			StateAuthMethod: "bearer",
+			StateType:       "bearer",
+			PlanType:        "devlxd",
+			Expect:          true,
 		},
 		{
 			// Same state, but the configuration asks for another identity

--- a/internal/auth/schema_validators.go
+++ b/internal/auth/schema_validators.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -64,4 +65,49 @@ func (v identityTypeValidator) validate(ctx context.Context, config tfsdk.Config
 	}
 
 	return diags
+}
+
+// identityCertificateValidator rejects a configured certificate for non-tls identities.
+type identityCertificateValidator struct{}
+
+func (v identityCertificateValidator) Description(_ context.Context) string {
+	return `Attribute "tls_certificate" can only be set for identities of type "tls".`
+}
+
+func (v identityCertificateValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v identityCertificateValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var authMethod types.String
+	var identityType types.String
+	var certificate types.String
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("auth_method"), &authMethod)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("type"), &identityType)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("tls_certificate"), &certificate)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// A certificate that is unknown until apply is checked again on create and update.
+	if certificate.IsNull() || certificate.IsUnknown() {
+		return
+	}
+
+	// See identityTypeModifier for why auth_method stands in for type.
+	if identityType.IsNull() {
+		identityType = authMethod
+	}
+
+	// An identity type that is unknown until apply is checked again on create and update.
+	if identityType.IsNull() || identityType.IsUnknown() || identityType.ValueString() == "tls" {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("tls_certificate"),
+		"Invalid attribute combination",
+		fmt.Sprintf("Certificate must not be set for identities of type %q", identityType.ValueString()),
+	)
 }

--- a/internal/auth/schema_validators_test.go
+++ b/internal/auth/schema_validators_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -97,6 +98,94 @@ func TestIdentityTypeValidator(t *testing.T) {
 			require.Len(t, dataSourceResp.Diagnostics.Warnings(), 1)
 			assert.Contains(t, resourceResp.Diagnostics.Warnings()[0].Detail(), test.ExpectWarn)
 			assert.Contains(t, dataSourceResp.Diagnostics.Warnings()[0].Detail(), test.ExpectWarn)
+		})
+	}
+}
+
+func TestIdentityCertificateValidator(t *testing.T) {
+	var tests = []struct {
+		Name         string
+		AuthMethod   any
+		IdentityType any
+		Certificate  any
+		ExpectError  string
+	}{
+		{
+			Name:         "No certificate",
+			IdentityType: "bearer",
+		},
+		{
+			Name:         "Certificate on tls type",
+			IdentityType: "tls",
+			Certificate:  "cert",
+		},
+		{
+			Name:        "Certificate on tls auth method",
+			AuthMethod:  "tls",
+			Certificate: "cert",
+		},
+		{
+			Name:         "Certificate on unknown type",
+			IdentityType: tftypes.UnknownValue,
+			Certificate:  "cert",
+		},
+		{
+			Name:         "Unknown certificate on bearer type",
+			IdentityType: "bearer",
+			Certificate:  tftypes.UnknownValue,
+		},
+		{
+			Name:         "Certificate on devlxd type",
+			IdentityType: "devlxd",
+			Certificate:  "cert",
+			ExpectError:  `Certificate must not be set for identities of type "devlxd"`,
+		},
+		{
+			Name:        "Certificate on bearer auth method",
+			AuthMethod:  "bearer",
+			Certificate: "cert",
+			ExpectError: `Certificate must not be set for identities of type "bearer"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			raw := tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"auth_method":     tftypes.String,
+						"type":            tftypes.String,
+						"tls_certificate": tftypes.String,
+					},
+				},
+				map[string]tftypes.Value{
+					"auth_method":     tftypes.NewValue(tftypes.String, test.AuthMethod),
+					"type":            tftypes.NewValue(tftypes.String, test.IdentityType),
+					"tls_certificate": tftypes.NewValue(tftypes.String, test.Certificate),
+				},
+			)
+
+			resp := &resource.ValidateConfigResponse{}
+			identityCertificateValidator{}.ValidateResource(t.Context(), resource.ValidateConfigRequest{
+				Config: tfsdk.Config{
+					Raw: raw,
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"auth_method":     schema.StringAttribute{Optional: true, Computed: true},
+							"type":            schema.StringAttribute{Optional: true, Computed: true},
+							"tls_certificate": schema.StringAttribute{Optional: true, Computed: true},
+						},
+					},
+				},
+			}, resp)
+
+			if test.ExpectError == "" {
+				require.False(t, resp.Diagnostics.HasError())
+				return
+			}
+
+			require.True(t, resp.Diagnostics.HasError())
+			assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), test.ExpectError)
 		})
 	}
 }

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -967,6 +967,13 @@ func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	// Cancel the update before the instance is changed if a configured device is owned by an identity.
+	diag := checkOwnedDevices(instanceName, instance.Config, devices)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
+		return
+	}
+
 	// Indicates if the instance has been just started.
 	instanceStarted := false
 	instanceStopped := isInstanceStopped(*instanceState)
@@ -1041,6 +1048,15 @@ func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest
 				return
 			}
 
+			config = common.MergeConfig(instance.Config, userConfig, plan.ComputedKeys())
+
+			// Cancel the update if a configured device became owned during the stop.
+			diag = checkOwnedDevices(instanceName, instance.Config, devices)
+			if diag != nil {
+				resp.Diagnostics.Append(diag)
+				return
+			}
+
 			instanceStopped = true
 		}
 	}
@@ -1051,10 +1067,11 @@ func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest
 		device[common.UserManagedBy] = common.DeviceManagedByTerraform
 	}
 
-	// Ensure that devices managed by the InstanceDeviceResource are not removed.
+	// Keep devices managed by the [InstanceDeviceResource] and devices owned by an identity.
 	for deviceName, device := range instance.Devices {
+		isOwned := isOwnedDevice(instance.Config, deviceName)
 		managedBy := device[common.UserManagedBy]
-		if managedBy != common.DeviceManagedByTerraform {
+		if managedBy != common.DeviceManagedByTerraform && !isOwned {
 			continue
 		}
 
@@ -1371,6 +1388,14 @@ func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, s
 	var syncDevices = make(map[string]map[string]string)
 
 	for deviceName, device := range instance.Devices {
+		// Leave owned devices out of the state to prevent provider from deleting them.
+		if isOwnedDevice(instance.Config, deviceName) {
+			// Remove owned device from the configured devices to prevent it from being
+			// added back into managed in the loop below.
+			delete(configuredDevices, deviceName)
+			continue
+		}
+
 		managedBy := device[common.UserManagedBy]
 
 		// Add non-managed devices for deletion by terraform plan.
@@ -1792,6 +1817,28 @@ func isInstanceRunning(s api.InstanceState) bool {
 // isInstanceReady returns true if its status is "Ready".
 func isInstanceReady(s api.InstanceState) bool {
 	return s.StatusCode == api.Ready
+}
+
+// isOwnedDevice reports whether the named device is owned by an identity.
+// LXD records the owner of a device in the instance configuration.
+func isOwnedDevice(instanceConfig map[string]string, deviceName string) bool {
+	_, ok := instanceConfig["volatile."+deviceName+".devlxd.owner"]
+	return ok
+}
+
+// checkOwnedDevices returns an error diagnostic if any of the configured devices is
+// owned by an identity. Such devices must not be modified by the provider.
+func checkOwnedDevices(instanceName string, instanceConfig map[string]string, devices map[string]map[string]string) diag.Diagnostic {
+	for deviceName := range devices {
+		if isOwnedDevice(instanceConfig, deviceName) {
+			return diag.NewErrorDiagnostic(
+				"Cannot modify an owned device",
+				fmt.Sprintf("Device %q on instance %q is owned by an identity", deviceName, instanceName),
+			)
+		}
+	}
+
+	return nil
 }
 
 // isInstanceStopped returns true if instance's status "Stopped".

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -560,6 +560,60 @@ func TestAccInstance_device(t *testing.T) {
 	})
 }
 
+func TestAccInstance_ownedDevice(t *testing.T) {
+	instanceName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "devlxd_volume_management")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccInstance_device_1(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.#", "1"),
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.0.name", "shared"),
+				),
+			},
+			{
+				// A configured device that became owned by an identity is
+				// dropped from the state on refresh.
+				PreConfig: func() {
+					server := acctest.InstanceServer(t)
+
+					instance, etag, err := server.GetInstance(instanceName)
+					if err != nil {
+						t.Fatalf("Failed to retrieve instance %q: %v", instanceName, err)
+					}
+
+					instance.Config["volatile.shared.devlxd.owner"] = "00000000-0000-0000-0000-000000000000"
+
+					op, err := server.UpdateInstance(instanceName, instance.Writable(), etag)
+					if err == nil {
+						err = op.Wait()
+					}
+
+					if err != nil {
+						t.Fatalf("Failed to set device owner on instance %q: %v", instanceName, err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_instance.instance1", "device.#", "0"),
+				),
+			},
+			{
+				// The owned device can no longer be configured by the provider.
+				Config:      acctest.Provider() + testAccInstance_device_1(instanceName),
+				ExpectError: regexp.MustCompile("Cannot modify an owned device"),
+			},
+		},
+	})
+}
+
 func TestAccInstance_addDevice(t *testing.T) {
 	instanceName := acctest.GenerateName(2, "-")
 


### PR DESCRIPTION
Adds support to generate DevLXD bearer tokens.
Additionally, the instance resource now ignores volumes with owner to prevent removing volumes created through DevLXD that are not managed by Terraform.


Requires rebase after:
- https://github.com/terraform-lxd/terraform-provider-lxd/pull/762
- https://github.com/terraform-lxd/terraform-provider-lxd/pull/770