### PR TITLE
image: Prefetch images before test and fix image alias panic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,14 @@ jobs:
         with:
           terraform_wrapper: false
 
+      # Fetch the test images so each instance is created from a locally cached image,
+      # keeping the image download out of the per-resource create timeout.
+      # Must match acctest.TestImage.
+      - name: Cache test image
+        run: |
+          lxc image copy images:alpine/edge local: --alias test-image
+          lxc image copy images:alpine/edge local: --vm --alias test-image-vm
+
       - name: Run acceptance tests
         run: make test
 
@@ -161,6 +169,15 @@ jobs:
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
+
+      # Fetch the test image so each instance is created from a locally cached image.
+      # This prevents image cache to be included in instance timeout (in case image downloads are slow)
+      # as well as a race when caching an image, since image operation lock is per-member.
+      # Must match acctest.TestImage.
+      - name: Cache test image
+        run: |
+          lxc image copy images:alpine/edge acctest: --alias test-image
+          lxc image copy images:alpine/edge acctest: --vm --alias test-image-vm
 
       - name: Run acceptance tests
         run: make test

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -24,8 +24,10 @@ resource "lxd_instance" "test1" {
 
 * `source_instance` - *Optional* - The source instance from which the image will be created. See reference below.
 
-* `aliases` - *Optional* - A list of aliases to assign to the image after
-	pulling.
+* `aliases` - *Optional* - A list of aliases to assign to the image.
+  An image is a singleton identified by its fingerprint, so its aliases are a shared set.
+  The provider manages only the aliases listed here (and those from `copied_aliases`).
+  Aliases created outside the provider are left untouched and are not reported in state.
 
 * `project` - *Optional* - Name of the project where the image will be stored.
 

--- a/internal/acctest/checks.go
+++ b/internal/acctest/checks.go
@@ -434,3 +434,15 @@ func PrintResourceState(t *testing.T, resName string) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+// InstanceServer returns an LXD instance server connected to the default test
+// remote and project. Use it when a test needs to interact with the cluster
+// directly, for example to set up or verify state outside the provider.
+func InstanceServer(t *testing.T) lxd.InstanceServer {
+	server, err := testProvider().InstanceServer("", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return server
+}

--- a/internal/image/resource_image.go
+++ b/internal/image/resource_image.go
@@ -301,28 +301,44 @@ func (r ImageResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	// Parse current (old) image aliases.
-	oldAliases := make([]string, len(image.Aliases))
+	// Get aliases currently present on the image, including any created outside the provider.
+	serverAliases := make([]string, len(image.Aliases))
 	for i, alias := range image.Aliases {
-		oldAliases[i] = alias.Name
+		serverAliases[i] = alias.Name
 	}
 
-	// Parse expected (new) image aliases.
-	copiedAliases := make([]string, 0, len(plan.CopiedAliases.Elements()))
-	diags := req.State.GetAttribute(ctx, path.Root("copied_aliases"), &copiedAliases)
+	// Get aliases copied from the source image. Tracked to ensure they are preserved.
+	copiedAliases, diags := ToAliasList(ctx, state.CopiedAliases)
 	resp.Diagnostics.Append(diags...)
 
-	newAliases, diags := ToAliasList(ctx, plan.Aliases)
+	// Aliases previously configured by the user.
+	prevAliases, diags := ToAliasList(ctx, state.Aliases)
 	resp.Diagnostics.Append(diags...)
 
-	newAliases = slices.Compact(append(newAliases, copiedAliases...))
+	// Aliases desired by the current configuration.
+	desiredAliases, diags := ToAliasList(ctx, plan.Aliases)
+	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Extract removed and added image aliases.
-	removed, added := utils.DiffSlices(oldAliases, newAliases)
+	// Aliases managed by the provider are the previously configured ones plus the copied ones.
+	// An image is a singleton keyed by fingerprint, so its alias set is shared.
+	// Aliases created outside the provider are not managed and must be left untouched.
+	managedAliases := slices.Compact(append(prevAliases, copiedAliases...))
+	desiredAliases = slices.Compact(append(desiredAliases, copiedAliases...))
+
+	// Restrict deletions to managed aliases that are still present on the image.
+	var managedOnServer []string
+	for _, alias := range serverAliases {
+		if utils.ValueInSlice(alias, managedAliases) {
+			managedOnServer = append(managedOnServer, alias)
+		}
+	}
+
+	removed, _ := utils.DiffSlices(managedOnServer, desiredAliases)
+	_, added := utils.DiffSlices(serverAliases, desiredAliases)
 
 	// Delete removed aliases.
 	for _, alias := range removed {
@@ -437,14 +453,10 @@ func (r ImageResource) SyncState(ctx context.Context, tfState *tfsdk.State, serv
 	configAliases, diags := ToAliasList(ctx, m.Aliases)
 	respDiags.Append(diags...)
 
-	copiedAliases, diags := ToAliasList(ctx, m.CopiedAliases)
-	respDiags.Append(diags...)
-
-	// Extract aliases from image that are either present in user defined
-	// config or are not copied from initial remote image.
+	// Report only aliases declared in config.
 	var aliases []string
 	for _, a := range image.Aliases {
-		if utils.ValueInSlice(a.Name, configAliases) || !utils.ValueInSlice(a.Name, copiedAliases) {
+		if utils.ValueInSlice(a.Name, configAliases) {
 			aliases = append(aliases, a.Name)
 		}
 	}

--- a/internal/image/resource_image_test.go
+++ b/internal/image/resource_image_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/canonical/lxd/shared/api"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/acctest"
 	provider_config "github.com/terraform-lxd/terraform-provider-lxd/internal/provider-config"
 )
@@ -174,6 +176,121 @@ func TestAccImage_addRemoveAlias(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_image.img2", "aliases.#", "1"),
 					resource.TestCheckResourceAttr("lxd_image.img2", "aliases.0", alias2),
 					resource.TestCheckResourceAttr("lxd_image.img2", "copied_aliases.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImage_manualAliasPreserved(t *testing.T) {
+	alias1 := acctest.GenerateName(2, "-")
+	alias2 := acctest.GenerateName(2, "-")
+	manualAlias := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccImage_aliases(alias1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_image.img2", "aliases.#", "1"),
+					resource.TestCheckResourceAttr("lxd_image.img2", "aliases.0", alias1),
+				),
+			},
+			{
+				// Create an alias outside the provider, then trigger an update by
+				// adding a config alias. The manually created alias must survive
+				// and must not appear in state.
+				PreConfig: func() {
+					server := acctest.InstanceServer(t)
+
+					target, _, err := server.GetImageAlias(alias1)
+					if err != nil {
+						t.Fatalf("Failed to resolve image alias %q: %v", alias1, err)
+					}
+
+					req := api.ImageAliasesPost{}
+					req.Name = manualAlias
+					req.Target = target.Target
+
+					err = server.CreateImageAlias(req)
+					if err != nil {
+						t.Fatalf("Failed to create image alias %q: %v", manualAlias, err)
+					}
+				},
+				Config: acctest.Provider() + testAccImage_aliases(alias1, alias2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_image.img2", "aliases.#", "2"),
+					resource.TestCheckTypeSetElemAttr("lxd_image.img2", "aliases.*", alias1),
+					resource.TestCheckTypeSetElemAttr("lxd_image.img2", "aliases.*", alias2),
+					func(_ *terraform.State) error {
+						server := acctest.InstanceServer(t)
+
+						_, _, err := server.GetImageAlias(manualAlias)
+						if err != nil {
+							return fmt.Errorf("Image alias %q not found: %w", manualAlias, err)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccImage_configAliasAdopted(t *testing.T) {
+	alias := acctest.GenerateName(2, "-")
+	manualAlias := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: func(_ *terraform.State) error {
+			server := acctest.InstanceServer(t)
+
+			_, _, err := server.GetImageAlias(manualAlias)
+			if err == nil {
+				return fmt.Errorf("Image alias %q was not deleted", manualAlias)
+			}
+
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccImage_aliases(alias),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_image.img2", "aliases.#", "1"),
+					resource.TestCheckResourceAttr("lxd_image.img2", "aliases.0", alias),
+				),
+			},
+			{
+				// Create an alias outside the provider, then declare that same alias
+				// in config. The provider must adopt the existing alias and apply
+				// cleanly rather than failing because it already exists.
+				PreConfig: func() {
+					server := acctest.InstanceServer(t)
+
+					target, _, err := server.GetImageAlias(alias)
+					if err != nil {
+						t.Fatalf("Failed to resolve image alias %q: %v", alias, err)
+					}
+
+					req := api.ImageAliasesPost{}
+					req.Name = manualAlias
+					req.Target = target.Target
+
+					err = server.CreateImageAlias(req)
+					if err != nil {
+						t.Fatalf("Failed to create image alias %q: %v", manualAlias, err)
+					}
+				},
+				Config: acctest.Provider() + testAccImage_aliases(alias, manualAlias),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_image.img2", "aliases.#", "2"),
+					resource.TestCheckTypeSetElemAttr("lxd_image.img2", "aliases.*", alias),
+					resource.TestCheckTypeSetElemAttr("lxd_image.img2", "aliases.*", manualAlias),
 				),
 			},
 		},


### PR DESCRIPTION
This PR ensures image download does not contribute to instance start when image download is slow and in LXD cluster prevents race conditions due to a lack of global locking for image download operation.

Additionally, it fixes an issue where Terraform provider panics when an image alias is set manually and not tracked in the state. Provider now ignores manually set aliases and only manages those that are explicitly configured or copied from the image source.