### PR TITLE
tests: Prevent instance test from removing cached test image

### DIFF
--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -1731,7 +1731,7 @@ resource "lxd_instance" "instance1" {
   image   = lxd_image.img.fingerprint
   running = true
 }
-	`, acctest.TestImage, name)
+	`, "images:openwrt/snapshot", name) // Do NOT use acctest.TestImage here because it will remove (pre-)cached image.
 }
 
 func testAccInstance_virtualMachine(name string) string {


### PR DESCRIPTION
Use different image from `acctest.TestImage` when testing container from cached image.
Otherwise, the image is removed and and members compete to cache the image when other tests require it afterwards.