### PR TITLE
storage|network: Match metadata configuration key placeholders

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -204,9 +204,6 @@ for more details on how to create a network in clustered mode.
   Each value is an object with a config map of local-scoped keys to apply for that member.
   Values in `member_overrides` take precedence over values from `config`.
 
-* `members` - *Computed* - Map of resolved local config for every cluster member, populated
-  after apply. Used by the provider to detect out-of-band changes (drift) on individual cluster members.
-
 * `project` - *Optional* - Name of the project where the network will be created.
 
 * `remote` - *Optional* - The remote in which the resource will be created. If
@@ -224,6 +221,9 @@ The following attributes are exported:
 * `ipv4_address` - The network's global IPv4 address in CIDR notation. For example `10.0.190.1/24`. When no such address exists, an empty string is set.
 
 * `ipv6_address` - The network's global IPv6 address in CIDR notation. For example `fd42:b40e:534a:b208::1/64`. When no such address exists, an empty string is set.
+
+* `members` - Map of resolved local config for every cluster member. Used by the provider to
+  detect out-of-band changes (drift) on individual cluster members.
 
 ## Importing
 

--- a/docs/resources/storage_pool.md
+++ b/docs/resources/storage_pool.md
@@ -79,13 +79,17 @@ for more details on how to create a storage pool in clustered mode.
   Each key is a cluster member name. Each value is a map of local-scoped config keys to apply for that member.
   Values in `member_overrides` take precedence over values from `config`.
 
-* `members` - *Computed* - Map of resolved local config for every cluster member, populated after
-  apply. Used by the provider to detect out-of-band changes (drift) on individual cluster members.
-
 * `project` - *Optional* - Name of the project where the storage pool will be stored.
 
 * `remote` - *Optional* - The remote in which the resource will be created. If
 	not provided, the provider's default remote will be used.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `members` - Map of resolved local config for every cluster member. Used by the provider to
+  detect out-of-band changes (drift) on individual cluster members.
 
 ## Importing
 

--- a/internal/common/lxd_config_member.go
+++ b/internal/common/lxd_config_member.go
@@ -1,0 +1,128 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/terraform-lxd/terraform-provider-lxd/internal/errors"
+)
+
+// MemberModel represents a per-member configuration of a clustered resource.
+type MemberModel struct {
+	Config types.Map `tfsdk:"config"`
+}
+
+// memberObjectType is the type of a single entry in the "member_overrides"
+// and "members" attributes.
+var memberObjectType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"config": types.MapType{ElemType: types.StringType},
+	},
+}
+
+// MemberOverridesHaveUnknownConfig reports whether any entry of an otherwise
+// known member_overrides map contains a config value that is only known
+// after apply. The outer map can be fully known (all member keys present)
+// while a nested override's "config" attribute, or a value within it,
+// remains unknown, which ToConfigMap cannot convert.
+func MemberOverridesHaveUnknownConfig(ctx context.Context, memberOverrides types.Map) bool {
+	if memberOverrides.IsNull() || memberOverrides.IsUnknown() {
+		return false
+	}
+
+	overrides := map[string]MemberModel{}
+	diags := memberOverrides.ElementsAs(ctx, &overrides, true)
+	if diags.HasError() {
+		return false
+	}
+
+	for _, override := range overrides {
+		if ConfigHasUnknownValue(override.Config) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ToMembersMapType converts per-member configuration into the value of the
+// computed "members" attribute.
+func ToMembersMapType(ctx context.Context, memberConfigs map[string]map[string]string) (types.Map, diag.Diagnostics) {
+	members := make(map[string]MemberModel, len(memberConfigs))
+
+	for memberName, memberConfig := range memberConfigs {
+		configValue, diags := types.MapValueFrom(ctx, types.StringType, ToNullableConfig(memberConfig))
+		if diags.HasError() {
+			return types.MapNull(memberObjectType), diags
+		}
+
+		members[memberName] = MemberModel{Config: configValue}
+	}
+
+	return types.MapValueFrom(ctx, memberObjectType, members)
+}
+
+// ResolveMemberConfigs splits config into cluster-wide and member-specific configuration.
+// Local keys found in config become the default for every cluster member, and each member's
+// override is merged on top of that default. The returned global config contains only the
+// keys that do not have local scope. Entity describes the resource in error messages,
+// for example `Storage pool "p1" (zfs)`.
+func ResolveMemberConfigs(ctx context.Context, entity string, config map[string]string, memberOverrides types.Map, memberNames []string, configKeys MetadataConfigKeys) (globalConfig map[string]string, memberConfigs map[string]map[string]string, err error) {
+	// Separate global and member-specific configuration.
+	globalConfig = make(map[string]string, len(config))
+	defaultMemberConfig := make(map[string]string)
+
+	for k, v := range config {
+		if configKeys.IsLocal(k) {
+			defaultMemberConfig[k] = v
+			continue
+		}
+
+		globalConfig[k] = v
+	}
+
+	// Set member-specific config from global config to all members by default.
+	memberConfigs = make(map[string]map[string]string, len(memberNames))
+	for _, memberName := range memberNames {
+		memberConfigs[memberName] = maps.Clone(defaultMemberConfig)
+	}
+
+	// Extract member-specific config overrides.
+	overrides := map[string]MemberModel{}
+	err = errors.FromDiagnostics(memberOverrides.ElementsAs(ctx, &overrides, true))
+	if err != nil {
+		return nil, nil, fmt.Errorf("Unable to extract member-specific config overrides: %v", err)
+	}
+
+	for memberName, override := range overrides {
+		memberConfig, ok := memberConfigs[memberName]
+		if !ok {
+			return nil, nil, fmt.Errorf("%s contains member-specific config override for a non-existent cluster member %q!", entity, memberName)
+		}
+
+		// Parse and apply member-specific override.
+		configMap, diags := ToConfigMap(ctx, override.Config)
+		err := errors.FromDiagnostics(diags)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Unable to convert member-specific config override to map: %v", err)
+		}
+
+		maps.Copy(memberConfig, configMap)
+
+		// Ensure member-specific config does not contain global keys.
+		for k := range memberConfig {
+			if !configKeys.IsLocal(k) {
+				return nil, nil, fmt.Errorf("%s: Invalid config key %q for member %q: Only member-specific keys are allowed in per-member configuration", entity, k, memberName)
+			}
+		}
+
+		// Store resolved config.
+		memberConfigs[memberName] = memberConfig
+	}
+
+	return globalConfig, memberConfigs, nil
+}

--- a/internal/common/lxd_config_member.go
+++ b/internal/common/lxd_config_member.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/terraform-lxd/terraform-provider-lxd/internal/errors"
 )
@@ -22,6 +23,39 @@ var memberObjectType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
 		"config": types.MapType{ElemType: types.StringType},
 	},
+}
+
+// MemberOverridesAttribute returns the schema of the "member_overrides" attribute, which
+// contains only local (member-specific) configuration that overrides the default values
+// defined in "config".
+func MemberOverridesAttribute() schema.MapNestedAttribute {
+	return schema.MapNestedAttribute{
+		Optional: true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"config": schema.MapAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
+				},
+			},
+		},
+	}
+}
+
+// MembersAttribute returns the schema of the "members" attribute, which contains the
+// resolved local (member-specific) config for all cluster members.
+func MembersAttribute() schema.MapNestedAttribute {
+	return schema.MapNestedAttribute{
+		Computed: true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"config": schema.MapAttribute{
+					Computed:    true,
+					ElementType: types.StringType,
+				},
+			},
+		},
+	}
 }
 
 // MemberOverridesHaveUnknownConfig reports whether any entry of an otherwise

--- a/internal/common/lxd_config_member_test.go
+++ b/internal/common/lxd_config_member_test.go
@@ -1,0 +1,176 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memberOverridesValue builds a member_overrides map value from the given per-member configs.
+func memberOverridesValue(t *testing.T, overrides map[string]map[string]attr.Value) types.Map {
+	t.Helper()
+
+	elements := make(map[string]attr.Value, len(overrides))
+	for memberName, config := range overrides {
+		configValue, diags := types.MapValue(types.StringType, config)
+		require.False(t, diags.HasError(), diags)
+
+		objectValue, diags := types.ObjectValue(memberObjectType.AttrTypes, map[string]attr.Value{
+			"config": configValue,
+		})
+		require.False(t, diags.HasError(), diags)
+
+		elements[memberName] = objectValue
+	}
+
+	value, diags := types.MapValue(memberObjectType, elements)
+	require.False(t, diags.HasError(), diags)
+
+	return value
+}
+
+func TestMemberOverridesHaveUnknownConfig(t *testing.T) {
+	ctx := context.Background()
+
+	assert.False(t, MemberOverridesHaveUnknownConfig(ctx, types.MapNull(memberObjectType)))
+	assert.False(t, MemberOverridesHaveUnknownConfig(ctx, types.MapUnknown(memberObjectType)))
+
+	known := memberOverridesValue(t, map[string]map[string]attr.Value{
+		"member-1": {"size": types.StringValue("10GiB")},
+	})
+	assert.False(t, MemberOverridesHaveUnknownConfig(ctx, known))
+
+	unknown := memberOverridesValue(t, map[string]map[string]attr.Value{
+		"member-1": {"size": types.StringUnknown()},
+	})
+	assert.True(t, MemberOverridesHaveUnknownConfig(ctx, unknown))
+}
+
+func TestToMembersMapType(t *testing.T) {
+	ctx := context.Background()
+
+	// A resource on a non-clustered server has no members, which must produce
+	// an empty map instead of a null one, as the attribute is computed.
+	empty, diags := ToMembersMapType(ctx, nil)
+	require.False(t, diags.HasError(), diags)
+	assert.False(t, empty.IsNull())
+	assert.Empty(t, empty.Elements())
+
+	members, diags := ToMembersMapType(ctx, map[string]map[string]string{
+		"member-1": {"source": "/dev/sdb"},
+		"member-2": {},
+	})
+	require.False(t, diags.HasError(), diags)
+
+	expected := memberOverridesValue(t, map[string]map[string]attr.Value{
+		"member-1": {"source": types.StringValue("/dev/sdb")},
+		"member-2": {},
+	})
+	assert.Equal(t, expected, members)
+}
+
+func TestResolveMemberConfigs(t *testing.T) {
+	ctx := context.Background()
+	memberNames := []string{"member-1", "member-2"}
+	configKeys := NewLocalMetadataConfigKeys([]string{"size", "source"})
+
+	config := map[string]string{
+		"source":         "/dev/sda",
+		"size":           "10GiB",
+		"zfs.clone_copy": "true",
+	}
+
+	overrides := memberOverridesValue(t, map[string]map[string]attr.Value{
+		"member-1": {"source": types.StringValue("/dev/sdb")},
+	})
+
+	globalConfig, memberConfigs, err := ResolveMemberConfigs(ctx, `Storage pool "p1" (zfs)`, config, overrides, memberNames, configKeys)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"zfs.clone_copy": "true"}, globalConfig)
+	assert.Equal(t, map[string]map[string]string{
+		"member-1": {"source": "/dev/sdb", "size": "10GiB"},
+		"member-2": {"source": "/dev/sda", "size": "10GiB"},
+	}, memberConfigs)
+}
+
+func TestResolveMemberConfigs_MetadataPattern(t *testing.T) {
+	keys := api.MetadataConfigurationConfigKeys{
+		Keys: []map[string]api.MetadataConfigurationConfigKey{
+			{"storage.project.{name}.backups_volume": {Scope: "local"}},
+		},
+	}
+	configKeys := NewMetadataConfigKeys(MetadataConfigKeySource{Keys: keys})
+	config := map[string]string{
+		"storage.project.default.backups_volume": "pool/backups",
+		"core.https_address":                     "127.0.0.1:8443",
+	}
+
+	globalConfig, memberConfigs, err := ResolveMemberConfigs(
+		context.Background(),
+		"LXD server",
+		config,
+		types.MapNull(memberObjectType),
+		[]string{"member-1"},
+		configKeys,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"core.https_address": "127.0.0.1:8443"}, globalConfig)
+	assert.Equal(t, map[string]map[string]string{
+		"member-1": {"storage.project.default.backups_volume": "pool/backups"},
+	}, memberConfigs)
+}
+
+func TestResolveMemberConfigs_MetadataPatternOverride(t *testing.T) {
+	keys := api.MetadataConfigurationConfigKeys{
+		Keys: []map[string]api.MetadataConfigurationConfigKey{
+			{"storage.project.{name}.backups_volume": {Scope: "local"}},
+		},
+	}
+	configKeys := NewMetadataConfigKeys(MetadataConfigKeySource{Keys: keys})
+	overrides := memberOverridesValue(t, map[string]map[string]attr.Value{
+		"member-1": {"storage.project.default.backups_volume": types.StringValue("pool/member-1")},
+	})
+
+	globalConfig, memberConfigs, err := ResolveMemberConfigs(
+		context.Background(),
+		"LXD server",
+		map[string]string{"storage.project.default.backups_volume": "pool/backups"},
+		overrides,
+		[]string{"member-1", "member-2"},
+		configKeys,
+	)
+	require.NoError(t, err)
+
+	assert.Empty(t, globalConfig)
+	assert.Equal(t, map[string]map[string]string{
+		"member-1": {"storage.project.default.backups_volume": "pool/member-1"},
+		"member-2": {"storage.project.default.backups_volume": "pool/backups"},
+	}, memberConfigs)
+}
+
+func TestResolveMemberConfigs_UnknownMember(t *testing.T) {
+	overrides := memberOverridesValue(t, map[string]map[string]attr.Value{
+		"member-9": {"source": types.StringValue("/dev/sdb")},
+	})
+
+	configKeys := NewLocalMetadataConfigKeys([]string{"source"})
+	_, _, err := ResolveMemberConfigs(context.Background(), `Storage pool "p1" (zfs)`, nil, overrides, []string{"member-1"}, configKeys)
+	assert.ErrorContains(t, err, `contains member-specific config override for a non-existent cluster member "member-9"`)
+}
+
+func TestResolveMemberConfigs_GlobalKeyInOverride(t *testing.T) {
+	overrides := memberOverridesValue(t, map[string]map[string]attr.Value{
+		"member-1": {"zfs.clone_copy": types.StringValue("true")},
+	})
+
+	configKeys := NewLocalMetadataConfigKeys([]string{"source"})
+	_, _, err := ResolveMemberConfigs(context.Background(), `Storage pool "p1" (zfs)`, nil, overrides, []string{"member-1"}, configKeys)
+	assert.ErrorContains(t, err, `Invalid config key "zfs.clone_copy" for member "member-1"`)
+}

--- a/internal/common/lxd_metadata.go
+++ b/internal/common/lxd_metadata.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 	"sync"
 
 	lxd "github.com/canonical/lxd/client"
@@ -9,11 +11,154 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+// MetadataConfigKeySource describes a metadata configuration group and an optional prefix to
+// apply to every key in that group.
+type MetadataConfigKeySource struct {
+	Keys   api.MetadataConfigurationConfigKeys
+	Prefix string
+}
+
+// MetadataConfigKeys matches concrete configuration keys to their metadata.
+type MetadataConfigKeys struct {
+	// Map of exact keys.
+	exact map[string]api.MetadataConfigurationConfigKey
+
+	// Map of keys with dynamic segments, such as wildcards or named placeholders.
+	patterns []metadataConfigKeyPattern
+}
+
+type metadataConfigKeyPattern struct {
+	regexp *regexp.Regexp
+	config api.MetadataConfigurationConfigKey
+}
+
 var (
 	metadataCache     = make(map[string]*api.MetadataConfiguration)
 	metadataCacheLock sync.RWMutex
 	metadataGroup     singleflight.Group
 )
+
+// NewMetadataConfigKeys builds a complete configuration key set from metadata groups.
+func NewMetadataConfigKeys(sources ...MetadataConfigKeySource) MetadataConfigKeys {
+	configKeys := MetadataConfigKeys{
+		exact: make(map[string]api.MetadataConfigurationConfigKey),
+	}
+
+	for _, source := range sources {
+		for _, keys := range source.Keys.Keys {
+			for key, config := range keys {
+				key = source.Prefix + key
+				pattern := compileMetadataKeyPattern(key)
+				if pattern != nil {
+					configKeys.patterns = append(configKeys.patterns, metadataConfigKeyPattern{regexp: pattern, config: config})
+					continue
+				}
+
+				configKeys.exact[key] = config
+			}
+		}
+	}
+
+	return configKeys
+}
+
+// NewLocalMetadataConfigKeys builds local-scope metadata for servers that do not expose metadata.
+func NewLocalMetadataConfigKeys(localKeys []string) MetadataConfigKeys {
+	keys := make(map[string]api.MetadataConfigurationConfigKey, len(localKeys))
+	for _, key := range localKeys {
+		keys[key] = api.MetadataConfigurationConfigKey{Scope: "local"}
+	}
+
+	return NewMetadataConfigKeys(MetadataConfigKeySource{
+		Keys: api.MetadataConfigurationConfigKeys{Keys: []map[string]api.MetadataConfigurationConfigKey{keys}},
+	})
+}
+
+// Lookup returns metadata for a concrete configuration key.
+func (k MetadataConfigKeys) Lookup(key string) (api.MetadataConfigurationConfigKey, bool) {
+	config, ok := k.exact[key]
+	if ok {
+		return config, true
+	}
+
+	for _, pattern := range k.patterns {
+		if pattern.regexp.MatchString(key) {
+			return pattern.config, true
+		}
+	}
+
+	return api.MetadataConfigurationConfigKey{}, false
+}
+
+// IsLocal reports whether a concrete key has local scope.
+func (k MetadataConfigKeys) IsLocal(key string) bool {
+	config, ok := k.Lookup(key)
+	return ok && config.Scope == "local"
+}
+
+// compileMetadataKeyPattern compiles a metadata key that contains placeholders into a regular
+// expression and returns nil for a literal key. The placeholder spellings are a convention of
+// the LXD metadata rather than a rule it defines. A trailing "*" matches the rest of the key,
+// a bracketed name such as "{name}" or "<name>" may contain dots, and an uppercase name such
+// as "NAME" matches a single segment.
+func compileMetadataKeyPattern(key string) *regexp.Regexp {
+	parts := strings.Split(key, ".")
+	dynamic := false
+
+	for i, part := range parts {
+		switch {
+		case part == "*" && i == len(parts)-1:
+			// A trailing wildcard matches the remaining suffix.
+			parts[i] = `.+`
+			dynamic = true
+		case isMetadataBracketedPlaceholder(part):
+			// Bracketed placeholders may contain dots, for example a project name "my.proj".
+			parts[i] = `.+`
+			dynamic = true
+		case isMetadataUppercasePlaceholder(part):
+			// Uppercase placeholders match one segment.
+			parts[i] = `[^.]+`
+			dynamic = true
+		default:
+			// Literal segments are quoted to match exactly.
+			parts[i] = regexp.QuoteMeta(part)
+		}
+	}
+
+	if !dynamic {
+		return nil
+	}
+
+	return regexp.MustCompile(`^` + strings.Join(parts, `\.`) + `$`)
+}
+
+// isMetadataBracketedPlaceholder reports whether part is spelled like {name} or <name>.
+func isMetadataBracketedPlaceholder(part string) bool {
+	if len(part) < 3 {
+		return false
+	}
+
+	isAngle := part[0] == '<' && part[len(part)-1] == '>'
+	isBrace := part[0] == '{' && part[len(part)-1] == '}'
+
+	return isAngle || isBrace
+}
+
+// isMetadataUppercasePlaceholder reports whether part is an uppercase identifier such as NAME
+// or NETWORK_NAME. A segment that starts with a digit, such as 1GB, is a literal.
+func isMetadataUppercasePlaceholder(part string) bool {
+	if part == "" || part[0] < 'A' || part[0] > 'Z' {
+		return false
+	}
+
+	for _, char := range part {
+		if char != '_' && (char < 'A' || char > 'Z') {
+			return false
+		}
+	}
+
+	return true
+}
 
 func ServerMetadataConfiguration(name string, server lxd.InstanceServer) (*api.MetadataConfiguration, error) {
 	metadataCacheLock.RLock()

--- a/internal/common/lxd_metadata_test.go
+++ b/internal/common/lxd_metadata_test.go
@@ -1,0 +1,192 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileMetadataKeyPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		key     string
+		match   bool
+	}{
+		{
+			name:    "Uppercase",
+			pattern: "bgp.peers.NAME.address",
+			key:     "bgp.peers.router1.address",
+			match:   true,
+		},
+		{
+			name:    "UppercaseExtraSegment",
+			pattern: "bgp.peers.NAME.address",
+			key:     "bgp.peers.site.router1.address",
+			match:   false,
+		},
+		{
+			name:    "UppercaseUnderscore",
+			pattern: "limits.networks.uplink_ips.ipv4.NETWORK_NAME",
+			key:     "limits.networks.uplink_ips.ipv4.uplink1",
+			match:   true,
+		},
+		{
+			name:    "Angle",
+			pattern: "volatile.<name>.hwaddr",
+			key:     "volatile.eth0.hwaddr",
+			match:   true,
+		},
+		{
+			name:    "AngleDottedSegment",
+			pattern: "volatile.<name>.hwaddr",
+			key:     "volatile.eth0.1.hwaddr",
+			match:   true,
+		},
+		{
+			name:    "Brace",
+			pattern: "storage.project.{name}.backups_volume",
+			key:     "storage.project.default.backups_volume",
+			match:   true,
+		},
+		{
+			name:    "BraceDottedSegment",
+			pattern: "storage.project.{name}.backups_volume",
+			key:     "storage.project.my.proj.backups_volume",
+			match:   true,
+		},
+		{
+			name:    "EmptyPlaceholder",
+			pattern: "storage.project.{name}.backups_volume",
+			key:     "storage.project..backups_volume",
+			match:   false,
+		},
+		{
+			name:    "Wildcard",
+			pattern: "user.*",
+			key:     "user.owner",
+			match:   true,
+		},
+		{
+			name:    "WildcardDottedSuffix",
+			pattern: "linux.sysctl.*",
+			key:     "linux.sysctl.net.ipv4.ip_forward",
+			match:   true,
+		},
+		{
+			name:    "EmptyWildcard",
+			pattern: "user.*",
+			key:     "user.",
+			match:   false,
+		},
+		{
+			name:    "MissingSegment",
+			pattern: "tunnel.NAME.local",
+			key:     "tunnel.local",
+			match:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pattern := compileMetadataKeyPattern(tt.pattern)
+			require.NotNil(t, pattern)
+			assert.Equal(t, tt.match, pattern.MatchString(tt.key))
+		})
+	}
+}
+
+func TestCompileMetadataKeyPattern_NumberIsLiteral(t *testing.T) {
+	assert.Nil(t, compileMetadataKeyPattern("limits.example.123NAME"))
+	assert.Nil(t, compileMetadataKeyPattern("limits.example.NAME123"))
+}
+
+func TestMetadataConfigKeys(t *testing.T) {
+	keys := api.MetadataConfigurationConfigKeys{
+		Keys: []map[string]api.MetadataConfigurationConfigKey{
+			{"core.https_address": {Scope: "global"}},
+			{"limits.hugepages.1GB": {Scope: "global"}},
+			{"storage.project.{name}.backups_volume": {Scope: "local"}},
+			{"user.*": {Scope: "global"}},
+		},
+	}
+
+	configKeys := NewMetadataConfigKeys(MetadataConfigKeySource{Keys: keys})
+
+	config, ok := configKeys.Lookup("core.https_address")
+	require.True(t, ok)
+	assert.Equal(t, "global", config.Scope)
+
+	_, ok = configKeys.Lookup("limits.hugepages.1GB")
+	assert.True(t, ok)
+
+	_, ok = configKeys.Lookup("limits.hugepages.10GB")
+	assert.False(t, ok)
+
+	assert.True(t, configKeys.IsLocal("storage.project.default.backups_volume"))
+	assert.True(t, configKeys.IsLocal("storage.project.my.proj.backups_volume"))
+
+	_, ok = configKeys.Lookup("user.owner.team")
+	assert.True(t, ok)
+
+	_, ok = configKeys.Lookup("unknown.key")
+	assert.False(t, ok)
+}
+
+func TestMetadataConfigKeysPrefix(t *testing.T) {
+	keys := api.MetadataConfigurationConfigKeys{
+		Keys: []map[string]api.MetadataConfigurationConfigKey{
+			{"size": {Scope: "local"}},
+		},
+	}
+
+	configKeys := NewMetadataConfigKeys(MetadataConfigKeySource{Keys: keys, Prefix: "volume."})
+
+	_, ok := configKeys.Lookup("volume.size")
+	assert.True(t, ok)
+	assert.True(t, configKeys.IsLocal("volume.size"))
+	_, ok = configKeys.Lookup("size")
+	assert.False(t, ok)
+}
+
+func TestMetadataConfigKeys_ExactKeyWins(t *testing.T) {
+	keys := api.MetadataConfigurationConfigKeys{
+		Keys: []map[string]api.MetadataConfigurationConfigKey{
+			{"foo.NAME.bar": {Scope: "global"}},
+			{"foo.x.bar": {Scope: "local"}},
+		},
+	}
+
+	configKeys := NewMetadataConfigKeys(MetadataConfigKeySource{Keys: keys})
+
+	assert.True(t, configKeys.IsLocal("foo.x.bar"))
+	assert.False(t, configKeys.IsLocal("foo.y.bar"))
+}
+
+func TestMetadataConfigKeys_EmptyScope(t *testing.T) {
+	keys := api.MetadataConfigurationConfigKeys{
+		Keys: []map[string]api.MetadataConfigurationConfigKey{
+			{"ipv4.address": {}},
+			{"tunnel.NAME.protocol": {}},
+		},
+	}
+
+	configKeys := NewMetadataConfigKeys(MetadataConfigKeySource{Keys: keys})
+
+	_, ok := configKeys.Lookup("ipv4.address")
+	assert.True(t, ok)
+	assert.False(t, configKeys.IsLocal("ipv4.address"))
+
+	_, ok = configKeys.Lookup("tunnel.gre1.protocol")
+	assert.True(t, ok)
+	assert.False(t, configKeys.IsLocal("tunnel.gre1.protocol"))
+}
+
+func TestLocalMetadataConfigKeys(t *testing.T) {
+	configKeys := NewLocalMetadataConfigKeys([]string{"source"})
+
+	assert.True(t, configKeys.IsLocal("source"))
+	assert.False(t, configKeys.IsLocal("unknown.key"))
+}

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -3,14 +3,12 @@ package network
 import (
 	"context"
 	"fmt"
-	"maps"
-	"slices"
+	"strings"
 	"time"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -42,11 +40,6 @@ type NetworkModel struct {
 	Managed types.Bool   `tfsdk:"managed"`
 	IPv4    types.String `tfsdk:"ipv4_address"`
 	IPv6    types.String `tfsdk:"ipv6_address"`
-}
-
-// NetworkMemberModel represents a per-member network configuration override.
-type NetworkMemberModel struct {
-	Config types.Map `tfsdk:"config"`
 }
 
 // NetworkResource represent LXD network resource.
@@ -176,31 +169,6 @@ func (r *NetworkResource) Configure(_ context.Context, req resource.ConfigureReq
 	r.provider = provider
 }
 
-// memberOverridesHaveUnknownConfig reports whether any entry of an otherwise
-// known member_overrides map contains a config value that is only known
-// after apply. The outer map can be fully known (all member keys present)
-// while a nested override's "config" attribute, or a value within it,
-// remains unknown, which ToConfigMap cannot convert.
-func memberOverridesHaveUnknownConfig(ctx context.Context, memberOverrides types.Map) bool {
-	if memberOverrides.IsNull() || memberOverrides.IsUnknown() {
-		return false
-	}
-
-	overrides := map[string]NetworkMemberModel{}
-	diags := memberOverrides.ElementsAs(ctx, &overrides, true)
-	if diags.HasError() {
-		return false
-	}
-
-	for _, override := range overrides {
-		if common.ConfigHasUnknownValue(override.Config) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (r *NetworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		// Nothing to do on destroy.
@@ -218,7 +186,7 @@ func (r *NetworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 	// or if config (global or within a member override) contains a value
 	// that is only known after apply (e.g. sourced from a resource applied
 	// later in the same plan).
-	if plan.Type.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || memberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
+	if plan.Type.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || common.MemberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
 		return
 	}
 
@@ -238,22 +206,7 @@ func (r *NetworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		return
 	}
 
-	members := make(map[string]NetworkMemberModel, len(memberNetworkConfigs))
-	for memberName, memberConfig := range memberNetworkConfigs {
-		memberConfigType, diags := types.MapValueFrom(ctx, types.StringType, common.ToNullableConfig(memberConfig))
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-
-		members[memberName] = NetworkMemberModel{Config: memberConfigType}
-	}
-
-	memberObjType := types.ObjectType{AttrTypes: map[string]attr.Type{
-		"config": types.MapType{ElemType: types.StringType},
-	}}
-
-	membersValue, diags := types.MapValueFrom(ctx, memberObjType, members)
+	membersValue, diags := common.ToMembersMapType(ctx, memberNetworkConfigs)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -558,7 +511,6 @@ func (r NetworkResource) SyncState(ctx context.Context, tfState *tfsdk.State, se
 		return respDiags
 	}
 
-	members := make(map[string]NetworkMemberModel, len(memberNetworkConfigs))
 	for memberName, memberConfig := range memberNetworkConfigs {
 		memberServer := server.UseTarget(memberName)
 
@@ -575,13 +527,6 @@ func (r NetworkResource) SyncState(ctx context.Context, tfState *tfsdk.State, se
 				memberConfig[k] = v
 			}
 		}
-
-		memberConfigType, diags := types.MapValueFrom(ctx, types.StringType, common.ToNullableConfig(memberConfig))
-		if diags.HasError() {
-			return diags
-		}
-
-		members[memberName] = NetworkMemberModel{Config: memberConfigType}
 	}
 
 	// Merge current network configuration with user provided configuration, stripping away
@@ -592,13 +537,7 @@ func (r NetworkResource) SyncState(ctx context.Context, tfState *tfsdk.State, se
 		return diags
 	}
 
-	memberObjType := types.ObjectType{
-		AttrTypes: map[string]attr.Type{
-			"config": types.MapType{ElemType: types.StringType},
-		},
-	}
-
-	membersValue, diags := types.MapValueFrom(ctx, memberObjType, members)
+	membersValue, diags := common.ToMembersMapType(ctx, memberNetworkConfigs)
 	if diags.HasError() {
 		return diags
 	}
@@ -636,7 +575,7 @@ func (m NetworkModel) TaintState(ctx context.Context, tfState *tfsdk.State) diag
 // containing local network configuration for each member (merged with default local
 // configuration from field "config").
 func (m NetworkModel) ParseNetworkConfigs(ctx context.Context, server lxd.InstanceServer, networkType string) (networkConfig map[string]string, memberConfigs map[string]map[string]string, err error) {
-	networkName := m.Name.ValueString()
+	networkEntity := fmt.Sprintf("Network %q (%s)", m.Name.ValueString(), networkType)
 
 	// Convert base network config to map.
 	networkConfig, diags := common.ToConfigMap(ctx, m.Config)
@@ -656,15 +595,16 @@ func (m NetworkModel) ParseNetworkConfigs(ctx context.Context, server lxd.Instan
 	// Extract member-specific config keys from server metadata.
 	// Use server version as metadata configuration cache key, as metadata configuration is the
 	// same across LXD servers with the same version.
-	allNetworkKeys, localNetworkKeys, err := m.networkConfigKeys(serverVersion, server, networkType)
+	configKeys, err := m.networkConfigKeys(serverVersion, server, networkType)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if len(allNetworkKeys) > 0 {
-		for k := range networkConfig {
-			if !slices.Contains(allNetworkKeys, k) {
-				return nil, nil, fmt.Errorf("Network %q (%s) does not support config key %q", networkName, networkType, k)
+	if server.CheckExtension("metadata_configuration") == nil {
+		for key := range networkConfig {
+			_, ok := configKeys.Lookup(key)
+			if !ok && !strings.HasPrefix(key, "user.") {
+				return nil, nil, fmt.Errorf("%s does not support config key %q", networkEntity, key)
 			}
 		}
 	}
@@ -674,7 +614,7 @@ func (m NetworkModel) ParseNetworkConfigs(ctx context.Context, server lxd.Instan
 	// Return early if LXD is not clustered or network type is OVN.
 	if !isServerClustered || networkType == "ovn" {
 		if hasMemberOverrides {
-			return nil, nil, fmt.Errorf(`Network %q (%s) cannot use member-specific config overrides unless LXD is clustered and the network type is not "ovn"`, networkName, networkType)
+			return nil, nil, fmt.Errorf(`%s cannot use member-specific config overrides unless LXD is clustered and the network type is not "ovn"`, networkEntity)
 		}
 
 		// Return early with global network config.
@@ -686,91 +626,33 @@ func (m NetworkModel) ParseNetworkConfigs(ctx context.Context, server lxd.Instan
 		return nil, nil, err
 	}
 
-	// Separate global and member-specific network configuration.
-	memberNetworkConfig := make(map[string]string)
-	for k, v := range networkConfig {
-		if slices.Contains(localNetworkKeys, k) {
-			memberNetworkConfig[k] = v
-			delete(networkConfig, k)
-		}
-	}
-
-	// Set member-specific config from global config to all members by default.
-	memberNetworkConfigs := make(map[string]map[string]string)
-	for _, memberName := range memberNames {
-		memberNetworkConfigs[memberName] = maps.Clone(memberNetworkConfig)
-	}
-
-	// Extract member-specific config overrides.
-	memberOverrides := map[string]NetworkMemberModel{}
-	err = errors.FromDiagnostics(m.MemberOverrides.ElementsAs(ctx, &memberOverrides, true))
-	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to extract member-specific config overrides: %v", err)
-	}
-
-	for memberName, override := range memberOverrides {
-		memberNetworkConfig, ok := memberNetworkConfigs[memberName]
-		if !ok {
-			return nil, nil, fmt.Errorf("Network %q (%s) contains member-specific config override for a non-existent cluster member %q!", networkName, networkType, memberName)
-		}
-
-		// Parse and apply member-specific override.
-		configMap, diags := common.ToConfigMap(ctx, override.Config)
-		err := errors.FromDiagnostics(diags)
-		if err != nil {
-			return nil, nil, fmt.Errorf("Unable to convert member-specific config override to map: %v", err)
-		}
-
-		maps.Copy(memberNetworkConfig, configMap)
-
-		// Ensure member-specific config does not contain global keys.
-		for k := range memberNetworkConfig {
-			if !slices.Contains(localNetworkKeys, k) {
-				return nil, nil, fmt.Errorf("Invalid config key %q for network member %q: Only member-specific keys are allowed in per-member configuration", k, memberName)
-			}
-		}
-
-		// Store resolved config.
-		memberNetworkConfigs[memberName] = memberNetworkConfig
-	}
-
-	return networkConfig, memberNetworkConfigs, nil
+	return common.ResolveMemberConfigs(ctx, networkEntity, networkConfig, m.MemberOverrides, memberNames, configKeys)
 }
 
-// networkConfigKeys retrieves a list of network configuration keys and their scope.
-func (m NetworkModel) networkConfigKeys(serverName string, server lxd.InstanceServer, networkType string) (allKeys []string, localKeys []string, err error) {
+// networkConfigKeys retrieves network configuration keys and their scope.
+func (m NetworkModel) networkConfigKeys(serverName string, server lxd.InstanceServer, networkType string) (common.MetadataConfigKeys, error) {
 	if server.CheckExtension("metadata_configuration") != nil {
-		localKeys = m.MemberSpecificKeys(networkType)
-		return nil, localKeys, nil
+		return common.NewLocalMetadataConfigKeys(m.MemberSpecificKeys(networkType)), nil
 	}
 
 	meta, err := common.ServerMetadataConfiguration(serverName, server)
 	if err != nil {
-		return nil, nil, err
+		return common.MetadataConfigKeys{}, err
 	}
 
 	typeConfigKey := "network-" + networkType
 	typeConfig, ok := meta.Configs[typeConfigKey]
 	if !ok {
-		return nil, nil, fmt.Errorf("Metadata configuration %q not found", typeConfigKey)
+		return common.MetadataConfigKeys{}, fmt.Errorf("Metadata configuration %q not found", typeConfigKey)
 	}
 
 	networkConfigKey := "network-conf"
 	networkConfig, ok := typeConfig[networkConfigKey]
 	if !ok {
-		return nil, nil, fmt.Errorf("Metadata configuration %q does not contain %q key", typeConfigKey, networkConfigKey)
+		return common.MetadataConfigKeys{}, fmt.Errorf("Metadata configuration %q does not contain %q key", typeConfigKey, networkConfigKey)
 	}
 
-	for _, configKeys := range networkConfig.Keys {
-		for k, v := range configKeys {
-			allKeys = append(allKeys, k)
-			if v.Scope == "local" {
-				localKeys = append(localKeys, k)
-			}
-		}
-	}
-
-	return allKeys, localKeys, nil
+	return common.NewMetadataConfigKeys(common.MetadataConfigKeySource{Keys: networkConfig}), nil
 }
 
 // ComputedKeys returns list of computed LXD config keys.

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -109,32 +109,9 @@ func (r NetworkResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				ElementType: types.StringType,
 			},
 
-			// Contains only local (member-specific) network configuration that
-			// overrides the default values defined in "config".
-			"member_overrides": schema.MapNestedAttribute{
-				Optional: true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"config": schema.MapAttribute{
-							Optional:    true,
-							ElementType: types.StringType,
-						},
-					},
-				},
-			},
+			"member_overrides": common.MemberOverridesAttribute(),
 
-			// Contains the resolved local (member-specific) config for all cluster members.
-			"members": schema.MapNestedAttribute{
-				Computed: true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"config": schema.MapAttribute{
-							Computed:    true,
-							ElementType: types.StringType,
-						},
-					},
-				},
-			},
+			"members": common.MembersAttribute(),
 
 			"managed": schema.BoolAttribute{
 				Computed: true,

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -47,6 +47,47 @@ func TestAccNetwork_basic(t *testing.T) {
 	})
 }
 
+func TestAccNetwork_userConfig(t *testing.T) {
+	networkName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccNetwork_memberOverrides(networkName, "bridge", map[string]string{
+					"user.terraform-provider-test": "value",
+				}, nil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_network.network", "config.user.terraform-provider-test", "value"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetwork_bgpPeers(t *testing.T) {
+	networkName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// The peer name is a key segment, matched against the "bgp.peers.NAME" metadata keys.
+				Config: acctest.Provider() + testAccNetwork_memberOverrides(networkName, "bridge", map[string]string{
+					"bgp.peers.peer1.address": "192.0.2.1",
+					"bgp.peers.peer1.asn":     "65000",
+				}, nil),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_network.network", "config.bgp.peers.peer1.address", "192.0.2.1"),
+					resource.TestCheckResourceAttr("lxd_network.network", "config.bgp.peers.peer1.asn", "65000"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccNetwork_unknownConfigValue verifies that a network can be created
 // with a config value that is only known after apply (e.g. sourced from
 // another resource applied in the same plan). Regression test for the

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -100,32 +100,9 @@ func (r StoragePoolResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Default:     mapdefault.StaticValue(types.MapValueMust(types.StringType, map[string]attr.Value{})),
 			},
 
-			// Contains only local (member-specific) storage pool configuration that
-			// overrides the default values defined in "config".
-			"member_overrides": schema.MapNestedAttribute{
-				Optional: true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"config": schema.MapAttribute{
-							Optional:    true,
-							ElementType: types.StringType,
-						},
-					},
-				},
-			},
+			"member_overrides": common.MemberOverridesAttribute(),
 
-			// Contains the resolved local (member-specific) config for all cluster members.
-			"members": schema.MapNestedAttribute{
-				Computed: true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"config": schema.MapAttribute{
-							Computed:    true,
-							ElementType: types.StringType,
-						},
-					},
-				},
-			},
+			"members": common.MembersAttribute(),
 		},
 	}
 }

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -3,8 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"maps"
-	"slices"
+	"strings"
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
@@ -36,11 +35,6 @@ type StoragePoolModel struct {
 	Config          types.Map    `tfsdk:"config"`
 	MemberOverrides types.Map    `tfsdk:"member_overrides"`
 	Members         types.Map    `tfsdk:"members"`
-}
-
-// StoragePoolMemberModel represents a per-member storage pool configuration override.
-type StoragePoolMemberModel struct {
-	Config types.Map `tfsdk:"config"`
 }
 
 // StoragePoolResource represents LXD storage pool resource.
@@ -151,31 +145,6 @@ func (r *StoragePoolResource) Configure(_ context.Context, req resource.Configur
 	r.provider = provider
 }
 
-// memberOverridesHaveUnknownConfig reports whether any entry of an otherwise
-// known member_overrides map contains a config value that is only known
-// after apply. The outer map can be fully known (all member keys present)
-// while a nested override's "config" attribute, or a value within it,
-// remains unknown, which ToConfigMap cannot convert.
-func memberOverridesHaveUnknownConfig(ctx context.Context, memberOverrides types.Map) bool {
-	if memberOverrides.IsNull() || memberOverrides.IsUnknown() {
-		return false
-	}
-
-	overrides := map[string]StoragePoolMemberModel{}
-	diags := memberOverrides.ElementsAs(ctx, &overrides, true)
-	if diags.HasError() {
-		return false
-	}
-
-	for _, override := range overrides {
-		if common.ConfigHasUnknownValue(override.Config) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (r *StoragePoolResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		// Nothing to do on destroy.
@@ -193,7 +162,7 @@ func (r *StoragePoolResource) ModifyPlan(ctx context.Context, req resource.Modif
 	// or if config (global or within a member override) contains a value
 	// that is only known after apply (e.g. sourced from a resource applied
 	// later in the same plan).
-	if plan.Driver.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || memberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
+	if plan.Driver.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || common.MemberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
 		return
 	}
 
@@ -213,22 +182,7 @@ func (r *StoragePoolResource) ModifyPlan(ctx context.Context, req resource.Modif
 		return
 	}
 
-	members := make(map[string]StoragePoolMemberModel, len(memberPoolConfigs))
-	for memberName, memberConfig := range memberPoolConfigs {
-		memberConfigType, diags := types.MapValueFrom(ctx, types.StringType, common.ToNullableConfig(memberConfig))
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-
-		members[memberName] = StoragePoolMemberModel{Config: memberConfigType}
-	}
-
-	memberObjType := types.ObjectType{AttrTypes: map[string]attr.Type{
-		"config": types.MapType{ElemType: types.StringType},
-	}}
-
-	membersValue, diags := types.MapValueFrom(ctx, memberObjType, members)
+	membersValue, diags := common.ToMembersMapType(ctx, memberPoolConfigs)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -502,7 +456,6 @@ func (r StoragePoolResource) SyncState(ctx context.Context, tfState *tfsdk.State
 		return respDiags
 	}
 
-	members := make(map[string]StoragePoolMemberModel, len(memberPoolConfigs))
 	for memberName, memberConfig := range memberPoolConfigs {
 		memberServer := server.UseTarget(memberName)
 
@@ -520,13 +473,6 @@ func (r StoragePoolResource) SyncState(ctx context.Context, tfState *tfsdk.State
 				memberConfig[k] = v
 			}
 		}
-
-		memberConfigType, diags := types.MapValueFrom(ctx, types.StringType, common.ToNullableConfig(memberConfig))
-		if diags.HasError() {
-			return diags
-		}
-
-		members[memberName] = StoragePoolMemberModel{Config: memberConfigType}
 	}
 
 	// LXD can modify the "source" config key, even if user provided the value.
@@ -542,11 +488,7 @@ func (r StoragePoolResource) SyncState(ctx context.Context, tfState *tfsdk.State
 		return diags
 	}
 
-	memberObjType := types.ObjectType{AttrTypes: map[string]attr.Type{
-		"config": types.MapType{ElemType: types.StringType},
-	}}
-
-	membersValue, diags := types.MapValueFrom(ctx, memberObjType, members)
+	membersValue, diags := common.ToMembersMapType(ctx, memberPoolConfigs)
 	if diags.HasError() {
 		return diags
 	}
@@ -580,7 +522,7 @@ func (m StoragePoolModel) TaintState(ctx context.Context, tfState *tfsdk.State) 
 // containing local storage pool configuration for each member (merged with default local
 // configuration from field "config").
 func (m StoragePoolModel) ParsePoolConfigs(ctx context.Context, server lxd.InstanceServer, driver string) (poolConfig map[string]string, memberConfigs map[string]map[string]string, err error) {
-	poolName := m.Name.ValueString()
+	poolEntity := fmt.Sprintf("Storage pool %q (%s)", m.Name.ValueString(), driver)
 
 	// Convert base pool config to map.
 	poolConfig, diags := common.ToConfigMap(ctx, m.Config)
@@ -612,15 +554,16 @@ func (m StoragePoolModel) ParsePoolConfigs(ctx context.Context, server lxd.Insta
 	// Extract member-specific config keys from server metadata.
 	// Use server version as metadata configuration cache key, as metadata configuration is the
 	// same across LXD servers with the same version.
-	allPoolKeys, localPoolKeys, err := m.storagePoolConfigKeys(serverVersion, server, driver)
+	configKeys, err := m.storagePoolConfigKeys(serverVersion, server, driver)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if len(allPoolKeys) > 0 {
-		for k := range poolConfig {
-			if !slices.Contains(allPoolKeys, k) {
-				return nil, nil, fmt.Errorf("Storage pool %q (%s) does not support config key %q", poolName, driver, k)
+	if server.CheckExtension("metadata_configuration") == nil {
+		for key := range poolConfig {
+			_, ok := configKeys.Lookup(key)
+			if !ok && !strings.HasPrefix(key, "user.") {
+				return nil, nil, fmt.Errorf("%s does not support config key %q", poolEntity, key)
 			}
 		}
 	}
@@ -630,7 +573,7 @@ func (m StoragePoolModel) ParsePoolConfigs(ctx context.Context, server lxd.Insta
 	// Return early if LXD is not clustered.
 	if !isServerClustered {
 		if hasMemberOverrides {
-			return nil, nil, fmt.Errorf("Storage pool %q (%s) member-specific config overrides are allowed only when LXD is clustered", poolName, driver)
+			return nil, nil, fmt.Errorf("%s member-specific config overrides are allowed only when LXD is clustered", poolEntity)
 		}
 
 		// Return early with global storage pool config.
@@ -642,108 +585,42 @@ func (m StoragePoolModel) ParsePoolConfigs(ctx context.Context, server lxd.Insta
 		return nil, nil, err
 	}
 
-	// Separate global and member-specific pool configuration.
-	memberPoolConfig := make(map[string]string)
-	for k, v := range poolConfig {
-		if slices.Contains(localPoolKeys, k) {
-			memberPoolConfig[k] = v
-			delete(poolConfig, k)
-		}
-	}
-
-	// Set member-specific config from global config to all members by default.
-	memberPoolConfigs := make(map[string]map[string]string)
-	for _, memberName := range memberNames {
-		memberPoolConfigs[memberName] = maps.Clone(memberPoolConfig)
-	}
-
-	// Extract member-specific config overrides.
-	memberOverrides := map[string]StoragePoolMemberModel{}
-	err = errors.FromDiagnostics(m.MemberOverrides.ElementsAs(ctx, &memberOverrides, true))
-	if err != nil {
-		return nil, nil, fmt.Errorf("Unable to extract member-specific config overrides: %v", err)
-	}
-
-	for memberName, override := range memberOverrides {
-		memberPoolConfig, ok := memberPoolConfigs[memberName]
-		if !ok {
-			return nil, nil, fmt.Errorf("Storage pool %q (%s) contains member-specific config override for a non-existent cluster member %q!", poolName, driver, memberName)
-		}
-
-		// Parse and apply member-specific override.
-		configMap, diags := common.ToConfigMap(ctx, override.Config)
-		err := errors.FromDiagnostics(diags)
-		if err != nil {
-			return nil, nil, fmt.Errorf("Unable to convert member-specific config override to map: %v", err)
-		}
-
-		maps.Copy(memberPoolConfig, configMap)
-
-		// Ensure member-specific config does not contain global keys.
-		for k := range memberPoolConfig {
-			if !slices.Contains(localPoolKeys, k) {
-				return nil, nil, fmt.Errorf("Invalid config key %q for storage pool member %q: Only member-specific keys are allowed in per-member configuration", k, memberName)
-			}
-		}
-
-		// Store resolved config.
-		memberPoolConfigs[memberName] = memberPoolConfig
-	}
-
-	return poolConfig, memberPoolConfigs, nil
+	return common.ResolveMemberConfigs(ctx, poolEntity, poolConfig, m.MemberOverrides, memberNames, configKeys)
 }
 
-// storagePoolConfigKeys retrieves a map of storage pool configuration keys and their scope.
-func (m StoragePoolModel) storagePoolConfigKeys(serverName string, server lxd.InstanceServer, driver string) (allKeys []string, localKeys []string, err error) {
+// storagePoolConfigKeys retrieves storage pool configuration keys and their scope.
+func (m StoragePoolModel) storagePoolConfigKeys(serverName string, server lxd.InstanceServer, driver string) (common.MetadataConfigKeys, error) {
 	if server.CheckExtension("metadata_configuration") != nil {
-		localKeys = m.MemberSpecificKeys(driver)
-		return nil, localKeys, nil
+		return common.NewLocalMetadataConfigKeys(m.MemberSpecificKeys(driver)), nil
 	}
 
 	meta, err := common.ServerMetadataConfiguration(serverName, server)
 	if err != nil {
-		return nil, nil, err
+		return common.MetadataConfigKeys{}, err
 	}
 
 	driverConfigKey := "storage-" + driver
 	driverConfig, ok := meta.Configs[driverConfigKey]
 	if !ok {
-		return nil, nil, fmt.Errorf("Metadata configuration %q not found", driverConfigKey)
+		return common.MetadataConfigKeys{}, fmt.Errorf("Metadata configuration %q not found", driverConfigKey)
 	}
 
 	// Parse pool config keys.
 	poolConfigKey := "pool-conf"
 	poolConfig, ok := driverConfig[poolConfigKey]
 	if !ok {
-		return nil, nil, fmt.Errorf("Metadata configuration %q does not contain %q key", driverConfigKey, poolConfigKey)
+		return common.MetadataConfigKeys{}, fmt.Errorf("Metadata configuration %q does not contain %q key", driverConfigKey, poolConfigKey)
 	}
 
-	for _, configKeys := range poolConfig.Keys {
-		for k, v := range configKeys {
-			allKeys = append(allKeys, k)
-			if v.Scope == "local" {
-				localKeys = append(localKeys, k)
-			}
-		}
-	}
+	sources := []common.MetadataConfigKeySource{{Keys: poolConfig}}
 
 	// Parse volume config keys.
 	volConfig, ok := driverConfig["volume-conf"]
 	if ok {
-		for _, configKeys := range volConfig.Keys {
-			for k, v := range configKeys {
-				// Pool accepts volume keys only with the "volume." prefix.
-				key := "volume." + k
-
-				allKeys = append(allKeys, key)
-				if v.Scope == "local" {
-					localKeys = append(localKeys, key)
-				}
-			}
-		}
+		sources = append(sources, common.MetadataConfigKeySource{Keys: volConfig, Prefix: "volume."})
 	}
 
-	return allKeys, localKeys, nil
+	return common.NewMetadataConfigKeys(sources...), nil
 }
 
 // ComputedKeys returns list of computed config keys.

--- a/internal/storage/resource_storage_pool_test.go
+++ b/internal/storage/resource_storage_pool_test.go
@@ -263,6 +263,25 @@ func TestAccStoragePool_config(t *testing.T) {
 	})
 }
 
+func TestAccStoragePool_userConfig(t *testing.T) {
+	poolName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.Provider() + testAccStoragePool_config(poolName, "dir", map[string]string{
+					"user.terraform-provider-test": "value",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "config.user.terraform-provider-test", "value"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccStoragePool_configSource(t *testing.T) {
 	drivers := []string{"dir", "zfs", "btrfs", "lvm"}
 


### PR DESCRIPTION
When the metadata API lists the available config keys, some keys contain placeholders, for example `bgp.peers.NAME.asn` or `user.*`. The provider compared config keys with these entries verbatim, so any key with a placeholder was rejected as unsupported.

This PR deduplicates shared logic between network and storage pool per-member configuration and adds a shared matcher in `internal/common` that resolves placeholders by the following rules:

1. A trailing `*` matches the rest of the key (`user.*`).
2. A placeholder wrapped in `{}` or `<>` matches any non-empty string, dots included (`storage.project.{name}.backups_volume`, project `my.proj` -> `storage.project.my.proj.backups_volume`).
3. An uppercase name matches exactly one segment (`bgp.peers.NAME.asn` -> Placeholder value does not allow dots).
4. Any other segment is matched literally.