### PR TITLE
storage|network: Test unsupported config key

### DIFF
--- a/internal/common/lxd_metadata.go
+++ b/internal/common/lxd_metadata.go
@@ -23,7 +23,7 @@ type MetadataConfigKeys struct {
 	// Map of exact keys.
 	exact map[string]api.MetadataConfigurationConfigKey
 
-	// Map of keys with dynamic segments, such as wildcards or named placeholders.
+	// List of keys with dynamic segments, such as wildcards or named placeholders.
 	patterns []metadataConfigKeyPattern
 }
 

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -159,11 +159,11 @@ func (r *NetworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		return
 	}
 
-	// Cannot expand members if type or member_overrides are not yet known,
+	// Cannot expand members if remote, type or member_overrides are not yet known,
 	// or if config (global or within a member override) contains a value
 	// that is only known after apply (e.g. sourced from a resource applied
 	// later in the same plan).
-	if plan.Type.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || common.MemberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
+	if plan.Remote.IsUnknown() || plan.Type.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || common.MemberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
 		return
 	}
 

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -83,6 +84,27 @@ func TestAccNetwork_bgpPeers(t *testing.T) {
 					resource.TestCheckResourceAttr("lxd_network.network", "config.bgp.peers.peer1.address", "192.0.2.1"),
 					resource.TestCheckResourceAttr("lxd_network.network", "config.bgp.peers.peer1.asn", "65000"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccNetwork_unsupportedConfigKey(t *testing.T) {
+	networkName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "metadata_configuration")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// A NAME placeholder matches exactly one segment.
+				Config: acctest.Provider() + testAccNetwork_memberOverrides(networkName, "bridge", map[string]string{
+					"bgp.peers.site.peer1.address": "192.0.2.1",
+				}, nil),
+				ExpectError: regexp.MustCompile(`does not support config key`),
 			},
 		},
 	})

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -538,6 +538,7 @@ func (m StoragePoolModel) ParsePoolConfigs(ctx context.Context, server lxd.Insta
 
 	if server.CheckExtension("metadata_configuration") == nil {
 		for key := range poolConfig {
+			// LXD accepts "user.*" keys on storage pools, but does not list them in the pool metadata.
 			_, ok := configKeys.Lookup(key)
 			if !ok && !strings.HasPrefix(key, "user.") {
 				return nil, nil, fmt.Errorf("%s does not support config key %q", poolEntity, key)

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -135,11 +135,11 @@ func (r *StoragePoolResource) ModifyPlan(ctx context.Context, req resource.Modif
 		return
 	}
 
-	// Cannot expand members if driver or member_overrides are not yet known,
+	// Cannot expand members if remote, driver or member_overrides are not yet known,
 	// or if config (global or within a member override) contains a value
 	// that is only known after apply (e.g. sourced from a resource applied
 	// later in the same plan).
-	if plan.Driver.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || common.MemberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
+	if plan.Remote.IsUnknown() || plan.Driver.IsUnknown() || plan.MemberOverrides.IsUnknown() || common.ConfigHasUnknownValue(plan.Config) || common.MemberOverridesHaveUnknownConfig(ctx, plan.MemberOverrides) {
 		return
 	}
 

--- a/internal/storage/resource_storage_pool_test.go
+++ b/internal/storage/resource_storage_pool_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -277,6 +278,27 @@ func TestAccStoragePool_userConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("lxd_storage_pool.storage_pool1", "config.user.terraform-provider-test", "value"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccStoragePool_unsupportedConfigKey(t *testing.T) {
+	poolName := acctest.GenerateName(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckAPIExtensions(t, "metadata_configuration")
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Config keys are validated against the metadata of the pool driver.
+				Config: acctest.Provider() + testAccStoragePool_config(poolName, "dir", map[string]string{
+					"zfs.pool_name": "unsupported",
+				}),
+				ExpectError: regexp.MustCompile(`does not support config key`),
 			},
 		},
 	})


### PR DESCRIPTION
Addresses comments from https://github.com/terraform-lxd/terraform-provider-lxd/pull/778